### PR TITLE
Survey respondent steps refactor

### DIFF
--- a/test/controllers/respondent_controller_test.exs
+++ b/test/controllers/respondent_controller_test.exs
@@ -23,7 +23,7 @@ defmodule Ask.RespondentControllerTest do
       survey = insert(:survey, project: project)
       conn = get conn, project_survey_respondent_path(conn, :index, project.id, survey.id)
       assert json_response(conn, 200)["data"]["respondents"] == []
-      assert json_response(conn, 200)["data"]["respondents_count"] == 0
+      assert json_response(conn, 200)["meta"]["count"] == 0
     end
 
     test "fetches responses on index", %{conn: conn, user: user} do
@@ -121,7 +121,7 @@ defmodule Ask.RespondentControllerTest do
 
     conn = post conn, project_survey_respondent_path(conn, :create, project.id, survey.id), file: file
     assert length(json_response(conn, 201)["data"]["respondents"]) == 5
-    assert json_response(conn, 201)["data"]["respondents_count"] == 14
+    assert json_response(conn, 201)["meta"]["count"] == 14
 
     all = Repo.all(from r in Respondent, where: r.survey_id == ^survey.id)
     assert length(all) == 14

--- a/test/controllers/respondent_controller_test.exs
+++ b/test/controllers/respondent_controller_test.exs
@@ -21,7 +21,7 @@ defmodule Ask.RespondentControllerTest do
     test "returns code 200 and empty list if there are no entries", %{conn: conn, user: user} do
       project = insert(:project, user: user)
       survey = insert(:survey, project: project)
-      conn = post conn, project_survey_respondent_path(conn, :index, project.id, survey.id)
+      conn = get conn, project_survey_respondent_path(conn, :index, project.id, survey.id)
       assert json_response(conn, 200)["data"]["respondents"] == []
       assert json_response(conn, 200)["data"]["respondents_count"] == 0
     end
@@ -31,7 +31,7 @@ defmodule Ask.RespondentControllerTest do
       survey = insert(:survey, project: project)
       respondent = insert(:respondent, survey: survey)
       response = insert(:response, respondent: respondent, value: "Yes")
-      conn = post conn, project_survey_respondent_path(conn, :index, project.id, survey.id)
+      conn = get conn, project_survey_respondent_path(conn, :index, project.id, survey.id)
       assert json_response(conn, 200)["data"]["respondents"] == [%{
                                                      "id" => respondent.id,
                                                      "phone_number" => Respondent.mask_phone_number(respondent.phone_number),
@@ -51,7 +51,7 @@ defmodule Ask.RespondentControllerTest do
       respondent = insert(:respondent, survey: survey)
       insert(:response, respondent: respondent, value: "Yes")
       assert_error_sent :forbidden, fn ->
-        post conn, project_survey_respondent_path(conn, :index, survey.project.id, survey.id)
+        get conn, project_survey_respondent_path(conn, :index, survey.project.id, survey.id)
       end
     end
 

--- a/web/controllers/respondent_controller.ex
+++ b/web/controllers/respondent_controller.ex
@@ -28,10 +28,10 @@ defmodule Ask.RespondentController do
     render(conn, "index.json", respondents: respondents, respondents_count: respondents_count)
   end
 
-  def conditional_limit param, limit do
+  def conditional_limit query, limit do
     case limit do
-      "" -> param
-      number -> param |> limit(^number)
+      "" -> query
+      number -> query |> limit(^number)
     end
   end
 

--- a/web/router.ex
+++ b/web/router.ex
@@ -31,8 +31,7 @@ defmodule Ask.Router do
       resources "/projects", ProjectController, except: [:new, :edit] do
         resources "/surveys", SurveyController, except: [:new, :edit] do
           post "/launch", SurveyController, :launch
-          resources "/respondents", RespondentController, only: [:create, :delete]
-          post "/respondents/index", RespondentController, :index
+          resources "/respondents", RespondentController, only: [:create, :index, :delete]
           get "/respondents/stats", RespondentController, :stats, as: :respondents_stats
         end
         resources "/questionnaires", QuestionnaireController, except: [:new, :edit]

--- a/web/router.ex
+++ b/web/router.ex
@@ -31,7 +31,8 @@ defmodule Ask.Router do
       resources "/projects", ProjectController, except: [:new, :edit] do
         resources "/surveys", SurveyController, except: [:new, :edit] do
           post "/launch", SurveyController, :launch
-          resources "/respondents", RespondentController, only: [:create, :index, :delete]
+          resources "/respondents", RespondentController, only: [:create, :delete]
+          post "/respondents/index", RespondentController, :index
           get "/respondents/stats", RespondentController, :stats, as: :respondents_stats
         end
         resources "/questionnaires", QuestionnaireController, except: [:new, :edit]
@@ -48,6 +49,6 @@ defmodule Ask.Router do
     pipe_through :browser
 
     get "/oauth_helper", OAuthHelperController, :index
-    get "/*path", PageController, :index        
-  end  
+    get "/*path", PageController, :index
+  end
 end

--- a/web/static/js/actions/respondents.js
+++ b/web/static/js/actions/respondents.js
@@ -8,7 +8,7 @@ export const RECEIVE_RESPONDENTS_ERROR = 'RECEIVE_RESPONDENTS_ERROR'
 export const RECEIVE_RESPONDENTS_STATS = 'RECEIVE_RESPONDENTS_STATS'
 
 export const fetchRespondents = (projectId, surveyId) => dispatch => {
-  api.fetchRespondentsWithLimit(projectId, surveyId, null)
+  api.fetchRespondentsWithLimit(projectId, surveyId, '')
     .then(respondents => dispatch(receiveRespondents(respondents)))
 }
 

--- a/web/static/js/actions/respondents.js
+++ b/web/static/js/actions/respondents.js
@@ -8,7 +8,12 @@ export const RECEIVE_RESPONDENTS_ERROR = 'RECEIVE_RESPONDENTS_ERROR'
 export const RECEIVE_RESPONDENTS_STATS = 'RECEIVE_RESPONDENTS_STATS'
 
 export const fetchRespondents = (projectId, surveyId) => dispatch => {
-  api.fetchRespondents(projectId, surveyId)
+  api.fetchRespondentsWithLimit(projectId, surveyId, null)
+    .then(respondents => dispatch(receiveRespondents(respondents)))
+}
+
+export const fetchRespondentsWithLimit = (projectId, surveyId, limit) => dispatch => {
+  api.fetchRespondentsWithLimit(projectId, surveyId, limit)
     .then(respondents => dispatch(receiveRespondents(respondents)))
 }
 

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -33,24 +33,28 @@ const apiFetch = (url, options) => {
 }
 
 const apiFetchJSON = (url, schema, options) => {
+  return apiFetchJSONWithCallback(url, schema, options, commonCallback)
+}
+
+const apiFetchJSONWithCallback = (url, schema, options, responseCallback) => {
   return apiFetch(url, options)
     .then(response => response.json().then(json => ({ json, response }))
   ).then(({ json, response }) => {
-    return handleResponse(response, () => normalize(camelizeKeys(json.data), schema))
+    return handleResponse(response, responseCallback(json, schema)
+    )
   })
 }
 
-const apiFetchJSON2 = (url, schema, options) => {
-  return apiFetch(url, options)
-    .then(response => response.json().then(json => ({ json, response }))
-  ).then(({ json, response }) => {
-    return handleResponse(response, () => {
-      let map = normalize(camelizeKeys(json.data.respondents), schema)
-      map.respondentsCount = json.data.respondents_count
-      return map
-    }
-    )
-  })
+const commonCallback = (json, schema) => {
+  return () => normalize(camelizeKeys(json.data), schema)
+}
+
+const respondentsCallback = (json, schema) => {
+  return () => {
+    let map = normalize(camelizeKeys(json.data.respondents), schema)
+    map.respondentsCount = json.data.respondents_count
+    return map
+  }
 }
 
 const handleResponse = (response, callback) => {
@@ -125,11 +129,12 @@ export const uploadRespondents = (survey, files) => {
   const formData = new FormData()
   formData.append('file', files[0])
 
-  return apiFetchJSON2(`projects/${survey.projectId}/surveys/${survey.id}/respondents`,
+  return apiFetchJSONWithCallback(`projects/${survey.projectId}/surveys/${survey.id}/respondents`,
     arrayOf(respondentSchema), {
       method: 'POST',
       body: formData
-    })
+    },
+    respondentsCallback)
 }
 
 export const removeRespondents = (survey) => {
@@ -140,10 +145,11 @@ export const fetchRespondentsWithLimit = (projectId, surveyId, limit) => {
   const formData = new FormData()
   if (limit) formData.append('limit', limit)
 
-  return apiFetchJSON2(`projects/${projectId}/surveys/${surveyId}/respondents/index`, arrayOf(respondentSchema), {
+  return apiFetchJSONWithCallback(`projects/${projectId}/surveys/${surveyId}/respondents/index`, arrayOf(respondentSchema), {
     method: 'POST',
     body: formData
-  })
+  },
+  respondentsCallback)
 }
 
 export const fetchRespondentsStats = (projectId, surveyId) => {

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -51,9 +51,9 @@ const commonCallback = (json, schema) => {
 
 const respondentsCallback = (json, schema) => {
   return () => {
-    let map = normalize(camelizeKeys(json.data.respondents), schema)
-    map.respondentsCount = json.data.respondents_count
-    return map
+    let normalized = normalize(camelizeKeys(json.data.respondents), schema)
+    normalized.respondentsCount = json.data.respondents_count
+    return normalized
   }
 }
 

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -52,7 +52,7 @@ const commonCallback = (json, schema) => {
 const respondentsCallback = (json, schema) => {
   return () => {
     let normalized = normalize(camelizeKeys(json.data.respondents), schema)
-    normalized.respondentsCount = parseInt(json.data.respondents_count)
+    normalized.respondentsCount = parseInt(json.meta.count)
     return normalized
   }
 }

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -142,14 +142,7 @@ export const removeRespondents = (survey) => {
 }
 
 export const fetchRespondentsWithLimit = (projectId, surveyId, limit) => {
-  const formData = new FormData()
-  if (limit) formData.append('limit', limit)
-
-  return apiFetchJSONWithCallback(`projects/${projectId}/surveys/${surveyId}/respondents/index`, arrayOf(respondentSchema), {
-    method: 'POST',
-    body: formData
-  },
-  respondentsCallback)
+  return apiFetchJSONWithCallback(`projects/${projectId}/surveys/${surveyId}/respondents/?limit=${limit}`, arrayOf(respondentSchema), {}, respondentsCallback)
 }
 
 export const fetchRespondentsStats = (projectId, surveyId) => {

--- a/web/static/js/components/SurveyRespondents.jsx
+++ b/web/static/js/components/SurveyRespondents.jsx
@@ -15,22 +15,22 @@ class SurveyRespondents extends Component {
     /* jQuery extend clones respondents object, in order to build an easy to manage structure without
     modify state */
     const respondents = generateResponsesDictionaryFor(jQuery.extend(true, {}, this.props.respondents))
-    const title = parseInt(Object.keys(respondents).length, 10) + " Respondents"
+    const title = parseInt(Object.keys(respondents).length, 10) + ' Respondents'
 
     if (Object.keys(respondents).length === 0) {
       return <div>Loading...</div>
     }
 
-    function generateResponsesDictionaryFor(rs){
+    function generateResponsesDictionaryFor(rs) {
       Object.keys(rs).forEach((respondentId, _) =>
         rs[respondentId].responses = responsesDictionaryFrom(rs[respondentId].responses)
       )
       return rs
     }
 
-    function responsesDictionaryFrom(responseArray){
+    function responsesDictionaryFrom(responseArray) {
       const res = {}
-      for (const key in responseArray){
+      for (const key in responseArray) {
         res[responseArray[key].name] = responseArray[key].value
       }
       return res
@@ -46,16 +46,16 @@ class SurveyRespondents extends Component {
       return Object.keys(rs)
     }
 
-    function hasResponded(rs, respondentId, fieldName){
+    function hasResponded(rs, respondentId, fieldName) {
       return Object.keys(rs[respondentId].responses).includes(fieldName)
     }
 
-    function responseOf(rs, respondentId, fieldName){
-      return hasResponded(rs, respondentId, fieldName) ? rs[respondentId].responses[fieldName] : "-"
+    function responseOf(rs, respondentId, fieldName) {
+      return hasResponded(rs, respondentId, fieldName) ? rs[respondentId].responses[fieldName] : '-'
     }
 
     return (
-      <CardTable title={ title }>
+      <CardTable title={title}>
         <thead>
           <tr>
             <th>Phone number</th>
@@ -69,11 +69,11 @@ class SurveyRespondents extends Component {
           {respondentKeys(respondents).map(respondentId =>
             <tr key={respondentId}>
               <td> {respondents[respondentId].phoneNumber}</td>
-              {allFieldNames(respondents).map(function(field){
-                return <td key={parseInt(respondentId, 10)+field}>{responseOf(respondents, respondentId, field)}</td>
+              {allFieldNames(respondents).map(function(field) {
+                return <td key={parseInt(respondentId, 10) + field}>{responseOf(respondents, respondentId, field)}</td>
               })}
               <td>
-                {respondents[respondentId].date ? new Date(respondents[respondentId].date).toUTCString() : "-"}
+                {respondents[respondentId].date ? new Date(respondents[respondentId].date).toUTCString() : '-'}
               </td>
             </tr>
           )}
@@ -91,4 +91,4 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-export default connect(mapStateToProps)(SurveyRespondents);
+export default connect(mapStateToProps)(SurveyRespondents)

--- a/web/static/js/containers/SurveyWizardRespondentsStep.jsx
+++ b/web/static/js/containers/SurveyWizardRespondentsStep.jsx
@@ -1,13 +1,10 @@
 import React, { PropTypes, Component } from 'react'
-import { Link } from 'react-router'
 import { connect } from 'react-redux'
 import Dropzone from 'react-dropzone'
 import { ConfirmationModal } from '../components/ConfirmationModal'
 import { uploadRespondents, removeRespondents } from '../api'
-// import * as actions from '../actions/surveys'
 import * as actions from '../actions/surveyEdit'
 import * as respondentsActions from '../actions/respondents'
-import * as routes from '../routes'
 
 class SurveyWizardRespondentsStep extends Component {
   static propTypes = {
@@ -16,13 +13,6 @@ class SurveyWizardRespondentsStep extends Component {
     respondentsCount: PropTypes.number.isRequired,
     dispatch: PropTypes.func.isRequired
   }
-
-  // componentDidMount() {
-  //   const { dispatch, projectId, surveyId } = this.props
-  //   if (projectId && surveyId) {
-  //     dispatch(respondentsActions.fetchRespondentsWithLimit(projectId, surveyId, 5))
-  //   }
-  // }
 
   handleSubmit(survey, files) {
     const { dispatch } = this.props
@@ -44,21 +34,13 @@ class SurveyWizardRespondentsStep extends Component {
   }
 
   render() {
-    const { survey, respondentsCount, respondents, projectId } = this.props
-// =======
-//     const { survey, respondentsCount, respondents } = this.props
-// >>>>>>> c58a02fd041d3e374d71909bc3d2ddba0590c79c
+    const { survey, respondentsCount, respondents } = this.props
 
     if (!survey) {
       return <div>Loading...</div>
     }
 
     if (respondentsCount !== 0) {
-// <<<<<<< HEAD
-// =======
-//       let respondentsIds = Object.keys(respondents).slice(0, 5)
-
-// >>>>>>> c58a02fd041d3e374d71909bc3d2ddba0590c79c
       return (
         <RespondentsContainer>
           <RespondentsList respondentsCount={respondentsCount}>
@@ -137,15 +119,7 @@ const RespondentsContainer = ({ children }) => {
 
 const mapStateToProps = (state, ownProps) => {
   return {
-// <<<<<<< HEAD
-//     respondents: state.respondents,
-//     respondentsCount: state.respondentsCount,
-//     projectId: ownProps.params.projectId,
-//     surveyId: ownProps.params.surveyId,
-//     survey: state.surveys[ownProps.params.surveyId]
-// =======
     respondentsCount: state.respondentsCount
-// >>>>>>> c58a02fd041d3e374d71909bc3d2ddba0590c79c
   }
 }
 

--- a/web/static/js/containers/SurveyWizardRespondentsStep.jsx
+++ b/web/static/js/containers/SurveyWizardRespondentsStep.jsx
@@ -1,11 +1,9 @@
-import React, { PropTypes, Component } from 'react'
-import { browserHistory } from 'react-router'
-import merge from 'lodash/merge'
+import React, { Component } from 'react'
 import { Link } from 'react-router'
 import { connect } from 'react-redux'
 import Dropzone from 'react-dropzone'
 import { ConfirmationModal } from '../components/ConfirmationModal'
-import { uploadRespondents, fetchQuestionnaires, removeRespondents } from '../api'
+import { uploadRespondents, removeRespondents } from '../api'
 import * as actions from '../actions/surveys'
 import * as respondentsActions from '../actions/respondents'
 import * as routes from '../routes'
@@ -14,7 +12,7 @@ class SurveyWizardRespondentsStep extends Component {
   componentDidMount() {
     const { dispatch, projectId, surveyId } = this.props
     if (projectId && surveyId) {
-      dispatch(respondentsActions.fetchRespondents(projectId, surveyId))
+      dispatch(respondentsActions.fetchRespondentsWithLimit(projectId, surveyId, 5))
     }
   }
 
@@ -36,20 +34,17 @@ class SurveyWizardRespondentsStep extends Component {
   }
 
   render() {
-    let files
     const { survey, respondentsCount, respondents, projectId } = this.props
 
     if (!survey) {
       return <div>Loading...</div>
     }
 
-    if (respondentsCount != 0) {
-      let respondentsIds = Object.keys(respondents).slice(0, 5)
-
+    if (respondentsCount !== 0) {
       return (
         <RespondentsContainer>
           <RespondentsList respondentsCount={respondentsCount}>
-            {respondentsIds.map((respondentId) =>
+            {Object.keys(respondents).map((respondentId) =>
               <PhoneNumberRow id={respondentId} phoneNumber={respondents[respondentId].phoneNumber} key={respondentId} />
             )}
           </RespondentsList>
@@ -129,7 +124,7 @@ const RespondentsContainer = ({ children }) => {
 const mapStateToProps = (state, ownProps) => {
   return {
     respondents: state.respondents,
-    respondentsCount: Object.keys(state.respondents).length,
+    respondentsCount: state.respondentsCount,
     projectId: ownProps.params.projectId,
     surveyId: ownProps.params.surveyId,
     survey: state.surveys[ownProps.params.surveyId]

--- a/web/static/js/containers/SurveyWizardRespondentsStep.jsx
+++ b/web/static/js/containers/SurveyWizardRespondentsStep.jsx
@@ -10,7 +10,7 @@ class SurveyWizardRespondentsStep extends Component {
   static propTypes = {
     survey: PropTypes.object,
     respondents: PropTypes.object.isRequired,
-    respondentsCount: PropTypes.number.isRequired,
+    respondentsCount: PropTypes.any.isRequired,
     dispatch: PropTypes.func.isRequired
   }
 

--- a/web/static/js/reducers/index.js
+++ b/web/static/js/reducers/index.js
@@ -8,6 +8,7 @@ import questionnaireEditor from './questionnaireEditor'
 import channels from './channels'
 import guisso from './guisso'
 import respondents from './respondents'
+import respondentsCount from './respondentsCount'
 
 export default combineReducers({
   routing,
@@ -17,6 +18,7 @@ export default combineReducers({
   questionnaires,
   questionnaireEditor,
   respondents,
+  respondentsCount,
   channels,
   guisso
 })

--- a/web/static/js/reducers/respondentsCount.js
+++ b/web/static/js/reducers/respondentsCount.js
@@ -1,0 +1,18 @@
+import * as actions from '../actions/respondents'
+
+export default (state = {}, action) => {
+  switch (action.type) {
+    case actions.CREATE_RESPONDENT:
+    case actions.UPDATE_RESPONDENT:
+      return 1
+    case actions.RECEIVE_RESPONDENTS:
+      if (action.response) {
+        return action.response.respondentsCount || {}
+      }
+      return state
+    case actions.REMOVE_RESPONDENTS:
+      return 0
+    default:
+      return state
+  }
+}

--- a/web/views/respondent_view.ex
+++ b/web/views/respondent_view.ex
@@ -2,7 +2,7 @@ defmodule Ask.RespondentView do
   use Ask.Web, :view
 
   def render("index.json", %{respondents: respondents, respondents_count: respondents_count}) do
-    %{data: %{respondents: render_many(respondents, Ask.RespondentView, "respondent.json"), respondents_count: respondents_count}}
+    %{data: %{respondents: render_many(respondents, Ask.RespondentView, "respondent.json")}, meta: %{count: respondents_count}}
   end
 
   def render("show.json", %{respondent: respondent}) do

--- a/web/views/respondent_view.ex
+++ b/web/views/respondent_view.ex
@@ -1,8 +1,8 @@
 defmodule Ask.RespondentView do
   use Ask.Web, :view
 
-  def render("index.json", %{respondents: respondents}) do
-    %{data: render_many(respondents, Ask.RespondentView, "respondent.json")}
+  def render("index.json", %{respondents: respondents, respondents_count: respondents_count}) do
+    %{data: %{respondents: render_many(respondents, Ask.RespondentView, "respondent.json"), respondents_count: respondents_count}}
   end
 
   def render("show.json", %{respondent: respondent}) do


### PR DESCRIPTION
Before this, the Survey Wizard retrieved all the respondents from the `respondents_controller`, only to show 5. This was limited on the UI. 
Now the `index` action from `respondents_controller` accepts a limit, and also returns the total count of respondents, to be able to display it on the UI.