### PR TITLE
(Fixes #178) Added skip_logic support to the Flow.

### DIFF
--- a/test/lib/runtime/flow_test.exs
+++ b/test/lib/runtime/flow_test.exs
@@ -54,88 +54,50 @@ defmodule Ask.FlowTest do
     assert {:end, _} = step
   end
 
-  # skip logic
-  test "when skip_logic is end it ends the flow" do
-    quiz = build(:questionnaire, steps: @skip_logic)
+  def init_quiz_and_send_response response do
     {:ok, flow, _} =
-      quiz
+      build(:questionnaire, steps: @skip_logic)
       |> Flow.start
       |> Flow.step
+    result = flow
+      |> Flow.step(response)
+  end
 
-    result =
-      flow
-      |> Flow.step("Y")
+  # skip logic
+  test "when skip_logic is end it ends the flow" do
+    result = init_quiz_and_send_response("Y")
 
     assert {:end, _} = result
   end
 
   test "when skip_logic is null it continues with next step" do
-    quiz = build(:questionnaire, steps: @skip_logic)
-    {:ok, flow, _} =
-      quiz
-      |> Flow.start
-      |> Flow.step
-
-    result =
-      flow
-      |> Flow.step("N")
+    result = init_quiz_and_send_response("N")
 
     assert {:ok, _, _} = result
   end
 
   test "when skip_logic is not present continues with next step" do
-    quiz = build(:questionnaire, steps: @skip_logic)
-    {:ok, flow, _} =
-      quiz
-      |> Flow.start
-      |> Flow.step
-
-    result =
-      flow
-      |> Flow.step("M")
+    result = init_quiz_and_send_response("M")
 
     assert {:ok, _, _} = result
   end
 
-  test "when skip_log is a valid id jumps to the specified id " do
-    quiz = build(:questionnaire, steps: @skip_logic)
-    {:ok, flow, _} =
-      quiz
-      |> Flow.start
-      |> Flow.step
-
-    {:ok, flow, _} =
-      flow
-      |> Flow.step("S")
+  test "when skip_logic is a valid id jumps to the specified id" do
+    {:ok, flow, _} = init_quiz_and_send_response("S")
 
     assert flow.current_step == 2
   end
 
-  describe "when skip_log is an invalid id" do
+  describe "when skip_logic is an invalid id" do
 
     test "when it doesn't exist raises" do
-      quiz = build(:questionnaire, steps: @skip_logic)
-      {:ok, flow, _} =
-        quiz
-        |> Flow.start
-        |> Flow.step
-
       assert_raise RuntimeError, fn ->
-        flow
-        |> Flow.step("A")
+        init_quiz_and_send_response("A")
       end
     end
 
     test "when the step is previous raises" do
-      quiz = build(:questionnaire, steps: @skip_logic)
-      {:ok, flow, _} =
-        quiz
-        |> Flow.start
-        |> Flow.step
-
-      {:ok, flow, _} =
-        flow
-        |> Flow.step("M")
+      {:ok, flow, _} = init_quiz_and_send_response("M")
 
       assert_raise RuntimeError, fn ->
         flow

--- a/test/lib/runtime/flow_test.exs
+++ b/test/lib/runtime/flow_test.exs
@@ -53,4 +53,96 @@ defmodule Ask.FlowTest do
     step = flow |> Flow.step("99")
     assert {:end, _} = step
   end
+
+  # skip logic
+  test "when skip_logic is end it ends the flow" do
+    quiz = build(:questionnaire, steps: @skip_logic)
+    {:ok, flow, _} =
+      quiz
+      |> Flow.start
+      |> Flow.step
+
+    result =
+      flow
+      |> Flow.step("Y")
+
+    assert {:end, _} = result
+  end
+
+  test "when skip_logic is null it continues with next step" do
+    quiz = build(:questionnaire, steps: @skip_logic)
+    {:ok, flow, _} =
+      quiz
+      |> Flow.start
+      |> Flow.step
+
+    result =
+      flow
+      |> Flow.step("N")
+
+    assert {:ok, _, _} = result
+  end
+
+  test "when skip_logic is not present continues with next step" do
+    quiz = build(:questionnaire, steps: @skip_logic)
+    {:ok, flow, _} =
+      quiz
+      |> Flow.start
+      |> Flow.step
+
+    result =
+      flow
+      |> Flow.step("M")
+
+    assert {:ok, _, _} = result
+  end
+
+  test "when skip_log is a valid id jumps to the specified id " do
+    quiz = build(:questionnaire, steps: @skip_logic)
+    {:ok, flow, _} =
+      quiz
+      |> Flow.start
+      |> Flow.step
+
+    {:ok, flow, _} =
+      flow
+      |> Flow.step("S")
+
+    assert flow.current_step == 2
+  end
+
+  describe "when skip_log is an invalid id" do
+
+    test "when it doesn't exist raises" do
+      quiz = build(:questionnaire, steps: @skip_logic)
+      {:ok, flow, _} =
+        quiz
+        |> Flow.start
+        |> Flow.step
+
+      assert_raise RuntimeError, fn ->
+        flow
+        |> Flow.step("A")
+      end
+    end
+
+    test "when the step is previous raises" do
+      quiz = build(:questionnaire, steps: @skip_logic)
+      {:ok, flow, _} =
+        quiz
+        |> Flow.start
+        |> Flow.step
+
+      {:ok, flow, _} =
+        flow
+        |> Flow.step("M")
+
+      assert_raise RuntimeError, fn ->
+        flow
+        |> Flow.step("Y")
+      end
+    end
+
+  end
+
 end

--- a/test/support/dummy_steps.ex
+++ b/test/support/dummy_steps.ex
@@ -50,6 +50,83 @@ defmodule Ask.DummySteps do
           "store" => "Perfect Number",
         }
       ]
+
+      @skip_logic [
+        %{
+          "id" => "aaa",
+          "type" => "multiple-choice",
+          "title" => "Do you smoke?",
+          "prompt" => %{
+            "sms" => "Do you smoke? Press 1 for YES, 2 for NO, 3 for MAYBE, 4 for SOMETIMES, 5 for ALWAYS",
+          },
+          "store" => "Smokes",
+          "choices" => [
+            %{
+              "value" => "Yes",
+              "responses" => ["Yes", "Y", "1"],
+              "skip_logic" => "end"
+            },
+            %{
+              "value" => "No",
+              "responses" => ["No", "N", "2"],
+              "skip_logic" => nil
+            },
+            %{
+              "value" => "Maybe",
+              "responses" => ["Maybe", "M", "3"],
+            },
+            %{
+              "value" => "Sometimes",
+              "responses" => ["Sometimes", "S", "4"],
+              "skip_logic" => "ccc"
+            },
+            %{
+              "value" => "ALWAYS",
+              "responses" => ["Always", "A", "5"],
+              "skip_logic" => "undefined_id"
+            }
+          ]
+        },
+        %{
+          "id" => "bbb",
+          "type" => "multiple-choice",
+          "title" => "Do you exercise?",
+          "prompt" => %{
+            "sms" => "Do you exercise? Press 1 for YES, 2 for NO",
+          },
+          "store" => "Exercises",
+          "choices" => [
+            %{
+              "value" => "Yes",
+              "responses" => ["Yes", "Y", "1"],
+              "skip_logic" => "aaa"
+            },
+            %{
+              "value" => "No",
+              "responses" => ["No", "N", "1"]
+            }
+          ]
+        },
+        %{
+          "id" => "ccc",
+          "type" => "multiple-choice",
+          "title" => "Is this questionnaire refreshing?",
+          "prompt" => %{
+            "sms" => "Is this questionnaire refreshing? Press 1 for YES, 2 for NO, 3 for MAYBE",
+          },
+          "store" => "Refresh",
+          "choices" => [
+            %{
+              "value" => "Yes",
+              "responses" => ["Yes", "Y", "1"]
+            },
+            %{
+              "value" => "No",
+              "responses" => ["No", "N", "1"]
+            }
+          ]
+        }
+      ]
     end
   end
 end


### PR DESCRIPTION
The behaviour for the skip logic is:

- continues to the next step when not present.
- continues to the next step when nil.
- ends the flow when it is set to "end"
- otherwise it assumes skip_logic is referencing a step by id:
  - raises if it doesn't exist
  - raises if the step is previous to the current one
  - continues to the step that has that id