### PR TITLE
JSON Schema for Questionnaire steps

### DIFF
--- a/lib/ask.ex
+++ b/lib/ask.ex
@@ -19,7 +19,8 @@ defmodule Ask do
     children = if Mix.env != :test && !IEx.started? do
       [
         worker(Ask.OAuthTokenServer, []),
-        worker(Ask.Runtime.Broker, [])
+        worker(Ask.Runtime.Broker, []),
+        worker(Ask.JsonSchema, [])
       | children]
     else
       children

--- a/lib/ask/json_schema.ex
+++ b/lib/ask/json_schema.ex
@@ -10,8 +10,6 @@ defmodule Ask.JsonSchema do
 
   def start_link do
     GenServer.start_link(__MODULE__, [], name: @server_ref)
-    IO.puts "STARTING JSON SCHEMA WORKER"
-    IO.inspect @server_ref
   end
 
   def init(_) do

--- a/lib/ask/json_schema.ex
+++ b/lib/ask/json_schema.ex
@@ -12,8 +12,9 @@ defmodule Ask.JsonSchema do
     GenServer.start_link(__MODULE__, [], name: @server_ref)
   end
 
-  def init(_) do
-    schema = File.read!(Application.app_dir(:ask) <> "/priv/schema.json")
+  def init([]), do: init(["schema.json"])
+  def init([schema_path]) do
+    schema = File.read!(Application.app_dir(:ask) <> "/priv/" <> schema_path)
              |> Poison.decode!
              |> ExJsonSchema.Schema.resolve
     {:ok, schema}
@@ -24,8 +25,8 @@ defmodule Ask.JsonSchema do
     {:reply, errors, schema}
   end
 
-  def validate(object, type) do
-    GenServer.call(@server_ref, {:validate, object, type})
+  def validate(object, type, server \\ @server_ref) do
+    GenServer.call(server, {:validate, object, type})
   end
 
   def errors_to_json(errors) do

--- a/lib/ask/json_schema.ex
+++ b/lib/ask/json_schema.ex
@@ -1,0 +1,69 @@
+defmodule Ask.JsonSchema do
+  @moduledoc ~S"""
+  A service which validates objects according to types defined in `schema.json`.
+  """
+  use GenServer
+
+  @server_ref {:global, __MODULE__}
+
+  def server_ref, do: @server_ref
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [], name: @server_ref)
+    IO.puts "STARTING JSON SCHEMA WORKER"
+    IO.inspect @server_ref
+  end
+
+  def init(_) do
+    schema = File.read!(Application.app_dir(:ask) <> "/priv/schema.json")
+             |> Poison.decode!
+             |> ExJsonSchema.Schema.resolve
+    {:ok, schema}
+  end
+
+  def handle_call({:validate, object, type}, _from, schema) do
+    errors = get_validation_errors(object, type, schema)
+    {:reply, errors, schema}
+  end
+
+  def validate(object, type) do
+    GenServer.call(@server_ref, {:validate, object, type})
+  end
+
+  def errors_to_json(errors) do
+    errors |> Enum.map(fn ({msg, _cols}) -> msg end)
+  end
+
+  defp get_validation_errors(object, type, schema) do
+    type_string = type |> to_string
+    type_schema = schema.schema["definitions"][type_string]
+
+    not_a_struct = case object do
+      %{__struct__: _} -> Map.from_struct(object)
+      _ -> object
+    end
+
+    string_keyed_object = ensure_key_strings(not_a_struct)
+
+    ## validate throws a BadMapError on certain kinds of invalid
+    ## input; absorb it (TODO fix ExJsonSchema upstream)
+    try do
+      ExJsonSchema.Validator.validate(schema, type_schema, string_keyed_object)
+    rescue
+      _ -> [{"Failed validation", []}]
+    end
+  end
+
+  defp ensure_key_strings(x) do
+    cond do
+      is_map x ->
+        Enum.reduce x, %{}, fn({k,v}, acc) ->
+          Map.put acc, to_string(k), ensure_key_strings(v)
+        end
+      is_list x ->
+        Enum.map(x, fn (v) -> ensure_key_strings(v) end)
+      true ->
+        x
+    end
+  end
+end

--- a/lib/mix/tasks/ask.validate_json_in_db.ex
+++ b/lib/mix/tasks/ask.validate_json_in_db.ex
@@ -1,0 +1,29 @@
+defmodule Mix.Tasks.Ask.ValidateJsonInDb do
+  use Mix.Task
+
+  alias Ask.{Questionnaire, Repo, JsonSchema}
+
+  @shortdoc """
+  Validates that questionnaires the DB conform to the current schema.json definition.
+  """
+
+  defp validate(quiz) do
+    {quiz.id, quiz.steps |> JsonSchema.validate(:steps)}
+  end
+
+  defp inspect_result({_, []}), do: []
+  defp inspect_result({id, validation_result}) do
+    Mix.shell.info "######################################################"
+    Mix.shell.info "Validation failed for quiz steps (quiz id: #{id})"
+    validation_result |> inspect |> Mix.shell.info
+  end
+
+  def run(_args) do
+    Mix.Task.run "app.start"
+
+    Questionnaire
+    |> Repo.all
+    |> Enum.map(&validate/1)
+    |> Enum.each(&inspect_result/1)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -50,6 +50,7 @@ defmodule Ask.Mixfile do
       {:sentry, "~> 1.0"},
       {:hackney, "~> 1.0"},
       {:tributary, "~> 0.2.1"},
+      {:ex_json_schema, "~> 0.5.2"}
    ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -9,6 +9,7 @@
   "db_connection": {:hex, :db_connection, "1.0.0-rc.4", "fad1f772c151cc6bde82412b8d72319968bc7221df8ef7d5e9d7fde7cb5c86b7", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
   "ecto": {:hex, :ecto, "2.0.4", "03fd3b9aa508b1383eb38c00ac389953ed22af53811aa2e504975a3e814a8d97", [:mix], [{:db_connection, "~> 1.0-rc.2", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.7.7", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.11.2", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},
+  "ex_json_schema": {:hex, :ex_json_schema, "0.5.2", "dc43c18139daf483db7ced34cb0face8d7b25088356362c4e4384cdff9523551", [:mix], []},
   "ex_machina": {:hex, :ex_machina, "1.0.2", "1cc49e1a09e3f7ab2ecb630c17f14c2872dc4ec145d6d05a9c3621936a63e34f", [:mix], [{:ecto, "~> 2.0", [hex: :ecto, optional: true]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "gettext": {:hex, :gettext, "0.11.0", "80c1dd42d270482418fa158ec5ba073d2980e3718bacad86f3d4ad71d5667679", [:mix], []},

--- a/priv/20161124.schema.json
+++ b/priv/20161124.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Ask JSON Schemas",
+
+  "definitions": {
+    "questionnaire": {
+      "type": "object",
+      "properties": {
+        "steps": { "$ref": "#/definitions/steps"}
+      },
+      "required": ["steps"]
+    },
+
+    "steps": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/step"
+      }
+    },
+
+    "step": {
+      "properties": {
+        "id": {"type": "string"},
+        "type": { "enum": ["multiple-choice", "numeric"] },
+        "title": {"type": "string"},
+        "prompt": { "$ref": "#/definitions/prompt"},
+        "store": { "type": "string" },
+        "choices": { "$ref": "#/definitions/choices" }
+      },
+      "required": ["id", "type", "title", "prompt", "store"]
+    },
+
+    "choices": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/choice"
+      }
+    },
+
+    "choice": {
+      "properties": {
+        "value": {"type": "string"},
+        "responses": {"$ref": "#/definitions/responses"}
+      },
+      "required": ["responses", "value"]
+    },
+
+    "responses": {
+      "type": "object",
+      "properties": {
+        "ivr": {"type": "array"},
+        "sms": {"type": "array"}
+      }
+    },
+
+    "prompt": {
+      "type": "object",
+      "properties": {
+        "sms": { "type": "string" },
+        "ivr": { "$ref": "#/definitions/ivr"}
+      }
+    },
+
+    "ivr": {
+      "type": "object",
+      "properties": {
+        "text": {"type": "string"},
+        "audio_source": {"enum": ["tts", "upload"]},
+        "audio_id": {"type": "string"}
+      },
+      "required": ["text", "audio_source"]
+    }
+  }
+}

--- a/priv/20161124.schema.json
+++ b/priv/20161124.schema.json
@@ -61,7 +61,8 @@
       "properties": {
         "sms": { "type": "string" },
         "ivr": { "$ref": "#/definitions/ivr"}
-      }
+      },
+      "additionalProperties": false
     },
 
     "ivr": {
@@ -71,6 +72,7 @@
         "audio_source": {"enum": ["tts", "upload"]},
         "audio_id": {"type": "string"}
       },
+      "additionalProperties": false,
       "required": ["text", "audio_source"]
     }
   }

--- a/priv/20161124.schema.json
+++ b/priv/20161124.schema.json
@@ -27,6 +27,7 @@
         "store": { "type": "string" },
         "choices": { "$ref": "#/definitions/choices" }
       },
+      "additionalProperties": false,
       "required": ["id", "type", "title", "prompt", "store"]
     },
 
@@ -40,9 +41,11 @@
     "choice": {
       "properties": {
         "value": {"type": "string"},
-        "responses": {"$ref": "#/definitions/responses"}
+        "responses": {"$ref": "#/definitions/responses"},
+        "skip_logic": {"type": ["string", "null"]}
       },
-      "required": ["responses", "value"]
+      "additionalProperties": false,
+      "required": ["responses", "value", "skip_logic"]
     },
 
     "responses": {

--- a/priv/repo/migrations/20161124171612_multilingual_questionnaires.exs
+++ b/priv/repo/migrations/20161124171612_multilingual_questionnaires.exs
@@ -28,7 +28,7 @@ defmodule Ask.Repo.Migrations.MultilingualQuestionnaires do
   def upgrade_step(step) do
     step
     |> add_store
-    |> replace_audio_with_audio_source
+    |> upgrade_prompt
     |> upgrade_choices
   end
 
@@ -39,6 +39,15 @@ defmodule Ask.Repo.Migrations.MultilingualQuestionnaires do
     end
   end
 
+  def upgrade_prompt(step) do
+    prompt = Kernel.get_in(step, ["prompt"])
+
+    new_prompt = prompt
+                |> replace_audio_with_audio_source
+                |> introduce_lang
+
+    Kernel.put_in(step, ["prompt"], new_prompt)
+  end
 
   def upgrade_choices(step) do
     case Kernel.get_in(step, ["choices"]) do
@@ -48,10 +57,22 @@ defmodule Ask.Repo.Migrations.MultilingualQuestionnaires do
           choice
           |> add_skip_logic
           |> remove_errors
+          |> upgrade_responses
         end)
 
         Kernel.put_in(step, ["choices"], new_choices)
     end
+  end
+
+  def upgrade_responses(choice) do
+    responses = Kernel.get_in(choice, ["responses"])
+
+    new_responses = case Kernel.get_in(responses, ["en"]) do
+                      nil -> %{"en" => responses}
+                      _ -> responses
+                    end
+
+    Kernel.put_in(choice, ["responses"], new_responses)
   end
 
   def add_skip_logic(choice) do
@@ -70,36 +91,42 @@ defmodule Ask.Repo.Migrations.MultilingualQuestionnaires do
     end
   end
 
-  def replace_audio_with_audio_source(step) do
-    IO.inspect step
-    case Kernel.get_in(step, ["prompt", "ivr"]) do
-      # It is ok for a step to not have an IVR prompt
-      nil -> step
+  def replace_audio_with_audio_source(prompt) do
+    case Kernel.get_in(prompt, ["ivr"]) do
+      # It is ok for a prompt to not have an IVR prompt
+      nil -> prompt
 
       # An empty IVR prompt at least has audio_source == "tts" and text == ""
-      "" -> Kernel.put_in(step, ["prompt", "ivr"], %{"audio_source" => "tts", "text" => ""})
+      "" -> Kernel.put_in(prompt, ["ivr"], %{"audio_source" => "tts", "text" => ""})
 
       # At this point IVR should be a map, so we check the structure is sound
       ivr_prompt ->
         case {Map.get(ivr_prompt, "audio"), Map.get(ivr_prompt, "audio_source")} do
           # At the very least, the IVR prompt must have an audio_source == "tts"
-          {nil, nil} -> Kernel.put_in(step, ["prompt", "ivr", "audio_source"], "tts")
+          {nil, nil} -> Kernel.put_in(prompt, ["ivr", "audio_source"], "tts")
 
           # This case is ok
-          {nil, _audio_source} -> step
+          {nil, _audio_source} -> prompt
 
           # We must replace audio with audio_source
           {audio, nil} ->
-            {_, new_step} = step
-                            |> Kernel.put_in(["prompt", "ivr", "audio_source"], audio)
-                            |> Kernel.pop_in(["prompt", "ivr", "audio"])
-            new_step
+            {_, new_prompt} = prompt
+                              |> Kernel.put_in(["ivr", "audio_source"], audio)
+                              |> Kernel.pop_in(["ivr", "audio"])
+            new_prompt
 
           # Here "audio" is likely a stalled branch of the map, we just drop it
           {_audio, _audio_source} ->
-            {_, new_step} = Kernel.pop_in(step, ["prompt", "ivr", "audio"])
-            new_step
+            {_, new_prompt} = Kernel.pop_in(prompt, ["ivr", "audio"])
+            new_prompt
         end
+    end
+  end
+
+  def introduce_lang(prompt) do
+    case Kernel.get_in(prompt, ["en"]) do
+      nil -> %{"en" => prompt}
+      _ -> prompt
     end
   end
 end

--- a/priv/repo/migrations/20161124171612_multilingual_questionnaires.exs
+++ b/priv/repo/migrations/20161124171612_multilingual_questionnaires.exs
@@ -29,12 +29,29 @@ defmodule Ask.Repo.Migrations.MultilingualQuestionnaires do
     step
     |> add_store
     |> replace_audio_with_audio_source
+    |> add_skip_logic
   end
 
   def add_store(step) do
     case Map.get(step, "store") do
       nil -> Kernel.put_in(step, ["store"], "")
       _ -> step
+    end
+  end
+
+  def add_skip_logic(step) do
+    case Kernel.get_in(step, ["choices"]) do
+      [] -> step
+      choices ->
+        new_choices = Enum.map(choices, &add_skip_logic_to_choice/1)
+        Kernel.put_in(step, ["choices"], new_choices)
+    end
+  end
+
+  def add_skip_logic_to_choice(choice) do
+    case Kernel.get_in(choice, ["skip_logic"]) do
+      nil -> Kernel.put_in(choice, ["skip_logic"], nil)
+      _skip_logic -> choice
     end
   end
 

--- a/priv/repo/migrations/20161124171612_multilingual_questionnaires.exs
+++ b/priv/repo/migrations/20161124171612_multilingual_questionnaires.exs
@@ -1,0 +1,73 @@
+defmodule Ask.Repo.Migrations.MultilingualQuestionnaires do
+  use Ecto.Migration
+
+  defp index_of(enum, field), do: Enum.find_index(enum, fn c -> c == field end)
+
+  def change do
+    Ask.Repo.transaction fn ->
+      quizzes = Ask.Repo.query!("select * from questionnaires")
+
+      id_index = quizzes.columns |> index_of("id")
+      steps_index = quizzes.columns |> index_of("steps")
+
+      quizzes.rows
+      |> Enum.each(fn quiz_row ->
+        upgraded_steps = upgrade(quiz_row |> Enum.at(steps_index))
+        Ask.Repo.query!("update questionnaires set steps = ? where id = ?", [upgraded_steps, quiz_row |> Enum.at(id_index)])
+      end)
+    end
+  end
+
+  def upgrade(steps) do
+    steps
+    |> Poison.decode!
+    |> Enum.map(&upgrade_step/1)
+    |> Poison.encode!
+  end
+
+  def upgrade_step(step) do
+    step
+    |> add_store
+    |> replace_audio_with_audio_source
+  end
+
+  def add_store(step) do
+    case Map.get(step, "store") do
+      nil -> Kernel.put_in(step, ["store"], "")
+      _ -> step
+    end
+  end
+
+  def replace_audio_with_audio_source(step) do
+    IO.inspect step
+    case Kernel.get_in(step, ["prompt", "ivr"]) do
+      # It is ok for a step to not have an IVR prompt
+      nil -> step
+
+      # An empty IVR prompt at least has audio_source == "tts" and text == ""
+      "" -> Kernel.put_in(step, ["prompt", "ivr"], %{"audio_source" => "tts", "text" => ""})
+
+      # At this point IVR should be a map, so we check the structure is sound
+      ivr_prompt ->
+        case {Map.get(ivr_prompt, "audio"), Map.get(ivr_prompt, "audio_source")} do
+          # At the very least, the IVR prompt must have an audio_source == "tts"
+          {nil, nil} -> Kernel.put_in(step, ["prompt", "ivr", "audio_source"], "tts")
+
+          # This case is ok
+          {nil, _audio_source} -> step
+
+          # We must replace audio with audio_source
+          {audio, nil} ->
+            {_, new_step} = step
+                            |> Kernel.put_in(["prompt", "ivr", "audio_source"], audio)
+                            |> Kernel.pop_in(["prompt", "ivr", "audio"])
+            new_step
+
+          # Here "audio" is likely a stalled branch of the map, we just drop it
+          {_audio, _audio_source} ->
+            {_, new_step} = Kernel.pop_in(step, ["prompt", "ivr", "audio"])
+            new_step
+        end
+    end
+  end
+end

--- a/priv/schema.json
+++ b/priv/schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Ask JSON Schemas",
+
+  "definitions": {
+    "questionnaire": {
+      "type": "object",
+      "properties": {
+        "steps": { "$ref": "#/definitions/steps"}
+      },
+      "required": ["steps"]
+    },
+
+    "steps": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/step"
+      }
+    },
+
+    "step": {
+      "properties": {
+        "id": {"type": "string"},
+        "type": { "enum": ["multiple-choice", "numeric"] },
+        "title": {"type": "string"},
+        "prompt": { "$ref": "#/definitions/prompt"},
+        "store": { "type": "string" },
+        "choices": { "$ref": "#/definitions/choices" }
+      },
+      "required": ["id", "type", "title", "prompt", "store"]
+    },
+
+    "choices": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/choice"
+      }
+    },
+
+    "choice": {
+      "properties": {
+        "value": {"type": "string"},
+        "responses": {"$ref": "#/definitions/responses"}
+      },
+      "required": ["responses", "value"]
+    },
+
+    "responses": {
+      "type": "object",
+      "properties": {
+        "ivr": {"type": "array"},
+        "sms": {"type": "array"}
+      }
+    },
+
+    "prompt": {
+      "type": "object",
+      "properties": {
+        "sms": { "type": "string" },
+        "ivr": { "$ref": "#/definitions/ivr"}
+      }
+    },
+
+    "ivr": {
+      "type": "object",
+      "properties": {
+        "text": {"type": "string"},
+        "audio_source": {"enum": ["tts", "upload"]},
+        "audio_id": {"type": "string"}
+      },
+      "required": ["text", "audio_source"]
+    }
+  }
+}

--- a/priv/schema.json
+++ b/priv/schema.json
@@ -27,6 +27,7 @@
         "store": { "type": "string" },
         "choices": { "$ref": "#/definitions/choices" }
       },
+      "additionalProperties": false,
       "required": ["id", "type", "title", "prompt", "store"]
     },
 
@@ -40,9 +41,11 @@
     "choice": {
       "properties": {
         "value": {"type": "string"},
-        "responses": {"$ref": "#/definitions/responses"}
+        "responses": {"$ref": "#/definitions/responses"},
+        "skip_logic": {"type": ["string", "null"]}
       },
-      "required": ["responses", "value"]
+      "additionalProperties": false,
+      "required": ["responses", "value", "skip_logic"]
     },
 
     "responses": {

--- a/priv/schema.json
+++ b/priv/schema.json
@@ -50,18 +50,30 @@
 
     "responses": {
       "type": "object",
+      "additionalProperties": { "$ref": "#/definitions/lang_responses" }
+    },
+
+    "lang_responses": {
+      "type": "object",
       "properties": {
         "ivr": {"type": "array"},
         "sms": {"type": "array"}
-      }
+      },
+      "additionalProperties": false
     },
 
     "prompt": {
       "type": "object",
+      "additionalProperties": { "$ref": "#/definitions/lang_prompt"}
+    },
+
+    "lang_prompt": {
+      "type": "object",
       "properties": {
         "sms": { "type": "string" },
         "ivr": { "$ref": "#/definitions/ivr"}
-      }
+      },
+      "additionalProperties": false
     },
 
     "ivr": {
@@ -71,6 +83,7 @@
         "audio_source": {"enum": ["tts", "upload"]},
         "audio_id": {"type": "string"}
       },
+      "additionalProperties": false,
       "required": ["text", "audio_source"]
     }
   }

--- a/test/controllers/questionnaire_controller_test.exs
+++ b/test/controllers/questionnaire_controller_test.exs
@@ -1,11 +1,13 @@
 defmodule Ask.QuestionnaireControllerTest do
   use Ask.ConnCase
 
-  alias Ask.{Project, Questionnaire}
+  alias Ask.{Project, Questionnaire, JsonSchema}
   @valid_attrs %{name: "some content", modes: ["sms", "ivr"], steps: []}
-  @invalid_attrs %{}
+  @invalid_attrs %{steps: []}
 
   setup %{conn: conn} do
+    GenServer.start_link(JsonSchema, [], name: JsonSchema.server_ref)
+
     user = insert(:user)
     conn = conn
       |> put_private(:test_user, user)

--- a/test/lib/json_schema_test.exs
+++ b/test/lib/json_schema_test.exs
@@ -212,24 +212,49 @@ defmodule Ask.StepsValidatorTest do
   end
 
   test "choice" do
-    ~s({"value": "Yes"}) |> invalid_choice("Choice requires responses")
-    ~s({"responses": {}}) |> invalid_choice("Choice requires value")
+    ~s({
+      "value": "Yes",
+      "skip_logic": ""
+    })
+    |> invalid_choice("Choice requires responses")
+
+    ~s({
+      "responses": {},
+      "skip_logic": ""
+    })
+    |> invalid_choice("Choice requires value")
 
     ~s({
       "value": {},
-      "responses": {}
+      "responses": {},
+      "skip_logic": ""
     })
     |> invalid_choice("Choice value is a string")
 
     ~s({
       "value": "Yes",
-      "responses": ""
+      "responses": "",
+      "skip_logic": ""
     })
     |> invalid_choice("Choice responses is an object")
 
     ~s({
       "value": "Yes",
       "responses": {}
+    })
+    |> invalid_choice("Choice requires skip_logic")
+
+    ~s({
+      "value": "Yes",
+      "responses": {},
+      "skip_logic": ""
+    })
+    |> valid_choice
+
+    ~s({
+      "value": "Yes",
+      "responses": {},
+      "skip_logic": null
     })
     |> valid_choice
   end

--- a/test/lib/json_schema_test.exs
+++ b/test/lib/json_schema_test.exs
@@ -1,0 +1,254 @@
+defmodule Ask.StepsValidatorTest do
+  use Ask.ModelCase
+
+  alias Ask.JsonSchema
+
+  setup_all do
+    GenServer.start_link(JsonSchema, [], name: JsonSchema.server_ref)
+    :ok
+  end
+
+  defp assert_ok(validation_result), do: assert([] == validation_result, inspect validation_result)
+  defp assert_invalid(validation_result, case_desc, thing) do
+    assert([] != validation_result, "#{case_desc}: #{thing}")
+  end
+
+  defp valid_thing(json_thing, thing_type) do
+    json_thing
+    |> Poison.decode!
+    |> JsonSchema.validate(thing_type)
+    |> assert_ok
+  end
+
+  defp invalid_thing(json_thing, thing_type, case_desc) do
+    json_thing
+    |> Poison.decode!
+    |> JsonSchema.validate(thing_type)
+    |> assert_invalid(case_desc, json_thing)
+  end
+
+  # TODO: generate these helpers with macros
+  defp valid_questionnaire(json), do: valid_thing(json, :questionnaire)
+  defp invalid_questionnaire(json, case_desc), do: invalid_thing(json, :questionnaire, case_desc)
+
+  defp valid_step(json), do: valid_thing(json, :step)
+  defp invalid_step(json, case_desc), do: invalid_thing(json, :step, case_desc)
+
+  defp valid_prompt(json), do: valid_thing(json, :prompt)
+  defp invalid_prompt(json, case_desc), do: invalid_thing(json, :prompt, case_desc)
+
+  defp valid_ivr(json), do: valid_thing(json, :ivr)
+  defp invalid_ivr(json, case_desc), do: invalid_thing(json, :ivr, case_desc)
+
+  defp valid_choice(json), do: valid_thing(json, :choice)
+  defp invalid_choice(json, case_desc), do: invalid_thing(json, :choice, case_desc)
+
+  defp valid_responses(json), do: valid_thing(json, :responses)
+  defp invalid_responses(json, case_desc), do: invalid_thing(json, :responses, case_desc)
+
+  test "questionnaire" do
+    ~s({})
+    |> invalid_questionnaire("Steps must be mandatory")
+
+    ~s({"steps": {}})
+    |> invalid_questionnaire("Questionnaire steps must be an array")
+
+    ~s({"steps": []})
+    |> valid_questionnaire
+  end
+
+  test "step" do
+    ~s({
+      "type": "numeric",
+      "title": "Smoke",
+      "prompt": {},
+      "store": "Smokes"
+    })
+    |> invalid_step("Step must have id")
+
+    ~s({
+        "id": {},
+        "type": "numeric",
+        "title": "Smoke",
+        "prompt": {},
+        "store": "Smokes"
+    })
+    |> invalid_step("Step id must be a string")
+
+    ~s({
+        "id": "fooId",
+        "type": "an-unsupported-step-type",
+        "title": "Smoke",
+        "prompt": {},
+        "store": "Smokes"
+    })
+    |> invalid_step("Step type should be limited to certain values")
+
+    ~s(
+    {
+      "id": "9616feb6-33c0-4feb-8aa8-84ba9a607103",
+      "type": "multiple-choice",
+      "prompt": {},
+      "store": ""
+    })
+    |> invalid_step("Step requires title")
+
+    ~s(
+    {
+      "id": "9616feb6-33c0-4feb-8aa8-84ba9a607103",
+      "type": "multiple-choice",
+      "title": {},
+      "prompt": {},
+      "store": ""
+    })
+    |> invalid_step("Step title must be a string")
+
+    ~s({
+      "id": "fooId",
+      "type": "numeric",
+      "title": "Smoke",
+      "store": "Smokes"
+    })
+    |> invalid_step("Step must have prompt")
+
+    ~s(
+    {
+      "id": "9616feb6-33c0-4feb-8aa8-84ba9a607103",
+      "type": "multiple-choice",
+      "title": "Smoke",
+      "prompt": {}
+    })
+    |> invalid_step("Step must have store")
+
+    ~s(
+    {
+      "id": "9616feb6-33c0-4feb-8aa8-84ba9a607103",
+      "type": "multiple-choice",
+      "title": "Smoke",
+      "prompt": {},
+      "store": {}
+    })
+    |> invalid_step("Store must be string")
+
+    ~s(
+    {
+      "id": "9616feb6-33c0-4feb-8aa8-84ba9a607103",
+      "type": "multiple-choice",
+      "title": "Smoke",
+      "prompt": {},
+      "store": "Smokes",
+      "choices": {}
+    })
+    |> invalid_step("Choices must be an array, if present")
+
+    ~s(
+    {
+      "id": "9616feb6-33c0-4feb-8aa8-84ba9a607103",
+      "title": "Smoke",
+      "type": "multiple-choice",
+      "prompt": {},
+      "store": "Smokes",
+      "choices": []
+    })
+    |> valid_step
+  end
+
+  test "prompt" do
+    ~s("") |> invalid_prompt("Prompt must be an object")
+    ~s({ "sms": {} }) |> invalid_prompt("Prompt sms must be a string")
+    ~s({ "ivr": "" }) |> invalid_prompt("Prompt ivr must be an object")
+
+    ~s({ "sms": "Do you smoke? Reply YES or NO" }) |> valid_prompt
+
+    ~s({
+      "ivr": {
+        "text": "Do you smoke?",
+        "audio_source": "tts"
+      }
+    })
+    |> valid_prompt
+
+    ~s({
+      "sms": "Do you smoke? Reply YES or NO",
+      "ivr": {
+        "text": "Do you smoke?",
+        "audio_source": "tts"
+      }
+    })
+    |> valid_prompt
+  end
+
+  test "ivr prompt" do
+    ~s({
+      "text": "foo"
+    })
+    |> invalid_ivr("IVR Prompt requires audio_source")
+
+    ~s({
+      "audio_source": "bar",
+      "text": "foo"
+    })
+    |> invalid_ivr("IVR Prompt requires audio_source to be tts or upload")
+
+    ~s({
+      "audio_source": "upload",
+      "text": "foo",
+      "audio_id": {}
+    })
+    |> invalid_ivr("IVR Prompt requires audio_id to be a string")
+
+    ~s({
+      "audio_source": "tts",
+      "text": "How many fingers do you have?"
+    })
+    |> valid_ivr
+
+    ~s({
+      "audio_source": "upload",
+      "text": "How many fingers do you have?",
+      "audio_id": "3b74aec8-1d5d-4b05-81e3-ab4856062615"
+    })
+    |> valid_ivr
+  end
+
+  test "choice" do
+    ~s({"value": "Yes"}) |> invalid_choice("Choice requires responses")
+    ~s({"responses": {}}) |> invalid_choice("Choice requires value")
+
+    ~s({
+      "value": {},
+      "responses": {}
+    })
+    |> invalid_choice("Choice value is a string")
+
+    ~s({
+      "value": "Yes",
+      "responses": ""
+    })
+    |> invalid_choice("Choice responses is an object")
+
+    ~s({
+      "value": "Yes",
+      "responses": {}
+    })
+    |> valid_choice
+  end
+
+  test "responses" do
+    ~s({
+      "ivr": {},
+      "sms": []
+    })
+    |> invalid_responses("Responses ivr must be an array")
+
+    ~s({
+      "ivr": [],
+      "sms": {}
+    })
+    |> invalid_responses("Responses sms must be an array")
+
+    ~s({"sms": []}) |> valid_responses
+    ~s({"ivr": []}) |> valid_responses
+    ~s({"ivr": ["1"], "sms": ["Y"]}) |> valid_responses
+  end
+end

--- a/test/lib/json_schema_test.exs
+++ b/test/lib/json_schema_test.exs
@@ -37,6 +37,9 @@ defmodule Ask.StepsValidatorTest do
   defp valid_prompt(json), do: valid_thing(json, :prompt)
   defp invalid_prompt(json, case_desc), do: invalid_thing(json, :prompt, case_desc)
 
+  defp valid_lang_prompt(json), do: valid_thing(json, :lang_prompt)
+  defp invalid_lang_prompt(json, case_desc), do: invalid_thing(json, :lang_prompt, case_desc)
+
   defp valid_ivr(json), do: valid_thing(json, :ivr)
   defp invalid_ivr(json, case_desc), do: invalid_thing(json, :ivr, case_desc)
 
@@ -45,6 +48,9 @@ defmodule Ask.StepsValidatorTest do
 
   defp valid_responses(json), do: valid_thing(json, :responses)
   defp invalid_responses(json, case_desc), do: invalid_thing(json, :responses, case_desc)
+
+  defp valid_lang_responses(json), do: valid_thing(json, :lang_responses)
+  defp invalid_lang_responses(json, case_desc), do: invalid_thing(json, :lang_responses, case_desc)
 
   test "questionnaire" do
     ~s({})
@@ -154,11 +160,24 @@ defmodule Ask.StepsValidatorTest do
   end
 
   test "prompt" do
-    ~s("") |> invalid_prompt("Prompt must be an object")
-    ~s({ "sms": {} }) |> invalid_prompt("Prompt sms must be a string")
-    ~s({ "ivr": "" }) |> invalid_prompt("Prompt ivr must be an object")
+    ~s({
+      "en": {
+        "foo": "bar"
+      }
+    }) |> invalid_prompt("Prompt must have a lang prompt structure")
 
-    ~s({ "sms": "Do you smoke? Reply YES or NO" }) |> valid_prompt
+    ~s({
+      "en": {},
+      "fr": {}
+    }) |> valid_prompt
+  end
+
+  test "lang prompt" do
+    ~s("") |> invalid_lang_prompt("Prompt must be an object")
+    ~s({ "sms": {} }) |> invalid_lang_prompt("Prompt sms must be a string")
+    ~s({ "ivr": "" }) |> invalid_lang_prompt("Prompt ivr must be an object")
+
+    ~s({ "sms": "Do you smoke? Reply YES or NO" }) |> valid_lang_prompt
 
     ~s({
       "ivr": {
@@ -166,7 +185,7 @@ defmodule Ask.StepsValidatorTest do
         "audio_source": "tts"
       }
     })
-    |> valid_prompt
+    |> valid_lang_prompt
 
     ~s({
       "sms": "Do you smoke? Reply YES or NO",
@@ -175,7 +194,7 @@ defmodule Ask.StepsValidatorTest do
         "audio_source": "tts"
       }
     })
-    |> valid_prompt
+    |> valid_lang_prompt
   end
 
   test "ivr prompt" do
@@ -261,19 +280,32 @@ defmodule Ask.StepsValidatorTest do
 
   test "responses" do
     ~s({
+      "en": {
+        "foo": "bar"
+      }
+    }) |> invalid_responses("Responses must have lang_responses structure")
+
+    ~s({
+      "en": {},
+      "fr": {}
+    }) |> valid_responses
+  end
+
+  test "lang_responses" do
+    ~s({
       "ivr": {},
       "sms": []
     })
-    |> invalid_responses("Responses ivr must be an array")
+    |> invalid_lang_responses("Responses ivr must be an array")
 
     ~s({
       "ivr": [],
       "sms": {}
     })
-    |> invalid_responses("Responses sms must be an array")
+    |> invalid_lang_responses("Responses sms must be an array")
 
-    ~s({"sms": []}) |> valid_responses
-    ~s({"ivr": []}) |> valid_responses
-    ~s({"ivr": ["1"], "sms": ["Y"]}) |> valid_responses
+    ~s({"sms": []}) |> valid_lang_responses
+    ~s({"ivr": []}) |> valid_lang_responses
+    ~s({"ivr": ["1"], "sms": ["Y"]}) |> valid_lang_responses
   end
 end


### PR DESCRIPTION
WIP Related to #316 (Enable multilingual questionnaires)

Next steps: use this infrastructure to validate against questionnaire tables to be migrated. Then evolve the schema to reflect the JSON structures introduced to support multilanguage. Finally, consider moving validation from questionnaire_controller to questionnaire model, so it can be taken advantage of from everywhere.