### PR TITLE
Do not render SurveyShow if respondent stats is not loaded

### DIFF
--- a/web/static/js/components/surveys/SurveyShow.jsx
+++ b/web/static/js/components/surveys/SurveyShow.jsx
@@ -83,7 +83,7 @@ class SurveyShow extends Component {
     const { survey, respondentsStats, respondentsQuotasStats, completedByDate, target, totalRespondents, questionnaire } = this.props
     const cumulativeCount = RespondentsChartCount.cumulativeCount(completedByDate, target)
 
-    if (!survey || !completedByDate || !questionnaire || !respondentsQuotasStats) {
+    if (!survey || !completedByDate || !questionnaire || !respondentsQuotasStats || !respondentsStats) {
       return <p>Loading...</p>
     }
 
@@ -235,7 +235,7 @@ const mapStateToProps = (state, ownProps) => {
   const respondentsStatsRoot = state.respondentsStats[ownProps.params.surveyId]
   const respondentsQuotasStats = state.respondentsQuotasStats.data
 
-  let respondentsStats = {}
+  let respondentsStats = null
   let completedRespondentsByDate = []
   // Default values
   let target = 1


### PR DESCRIPTION
When navigating to survey show after creating a survey, respondent
stats were not yet loaded, and yielded an error when attempting to
access the count method of one of its properties.

`respondentStats.pending.count => pending is undefined`

The actions log was the following:

```
SURVEY_SAVED
SURVEY_RECEIVE
@@router/LOCATION_CHANGE
SURVEY_FETCH
Error rendering survey show since stats were not yet received
SURVEY_RECEIVE
@@router/LOCATION_CHANGE
SURVEY_FETCH
RECEIVE_RESPONDENTS_QUOTAS_STATS
RECEIVE_RESPONDENTS_STATS => Stats are received here
RECEIVE_RESPONDENTS_QUOTAS_STATS
RECEIVE_RESPONDENTS_STATS
SURVEY_RECEIVE
QUESTIONNAIRE_FETCH
QUESTIONNAIRE_RECEIVE
```

Added a check for the survey show component to render only the Loading
indicator if respondentStats is not yet loaded. Default value set to
null instead of empty object to ensure the check succeeds.

Fixes #344