### PR TITLE
Fix react proptype for respondentsQuotasStats in SurveyShow

### DIFF
--- a/web/static/js/components/surveys/SurveyShow.jsx
+++ b/web/static/js/components/surveys/SurveyShow.jsx
@@ -18,7 +18,7 @@ class SurveyShow extends Component {
     survey: React.PropTypes.object,
     questionnaire: React.PropTypes.object,
     respondentsStats: React.PropTypes.object,
-    respondentsQuotasStats: React.PropTypes.object,
+    respondentsQuotasStats: React.PropTypes.array,
     completedByDate: React.PropTypes.array,
     target: React.PropTypes.number,
     totalRespondents: React.PropTypes.number


### PR DESCRIPTION
Does not fix #377, just removes initial warning for prop type