### PR TITLE
Use LONGTEXT to store the respondent groups samples (fixes issue with…

### DIFF
--- a/priv/repo/migrations/20170117191259_modify_respondent_group_sample_to_long_text.exs
+++ b/priv/repo/migrations/20170117191259_modify_respondent_group_sample_to_long_text.exs
@@ -1,0 +1,15 @@
+defmodule Ask.Repo.Migrations.ModifyRespondentGroupSampleToLongText do
+  use Ecto.Migration
+
+  def up do
+    alter table(:respondent_groups) do
+      modify :sample, :longtext
+    end
+  end
+
+  def down do
+    alter table(:respondent_groups) do
+      modify :sample, :string
+    end
+  end
+end


### PR DESCRIPTION
… surveys containing really long numbers)