### PR TITLE
A more strict JSON schema that defines specific attributes for each step type

### DIFF
--- a/priv/schema.json
+++ b/priv/schema.json
@@ -21,23 +21,68 @@
     },
 
     "step": {
+      "oneOf": [
+        { "$ref": "#/definitions/multiple-choice" },
+        { "$ref": "#/definitions/numeric" },
+        { "$ref": "#/definitions/explanation" },
+        { "$ref": "#/definitions/language-selection" }
+      ]
+    },
+
+    "multiple-choice": {
       "properties": {
         "id": {"type": "string"},
-        "type": { "enum": ["multiple-choice", "numeric", "language-selection", "explanation"] },
+        "type": { "enum": ["multiple-choice"] },
         "title": {"type": "string"},
-        "prompt": { "anyOf": [{"$ref": "#/definitions/prompt"}, {"$ref": "#/definitions/lang_prompt"}]},
-        "store": { "type": "string" },
+        "prompt": { "$ref": "#/definitions/prompt"},
         "choices": { "$ref": "#/definitions/choices" },
-        "language_choices": { "type": "array" },
+        "store": { "type": "string" }
+      },
+      "additionalProperties": false,
+      "required": ["id", "type", "title", "prompt", "choices", "store"]
+    },
+
+    "numeric": {
+      "properties": {
+        "id": {"type": "string"},
+        "type": { "enum": ["numeric"] },
+        "title": {"type": "string"},
+        "prompt": { "$ref": "#/definitions/prompt"},
         "min_value": {"type": ["integer", "null"]},
         "max_value": {"type": ["integer", "null"]},
         "ranges_delimiters": {"type": ["string", "null"]},
         "ranges": {"$ref": "#/definitions/ranges"},
+        "store": { "type": "string" }
+      },
+      "additionalProperties": false,
+      "required": ["id", "type", "title", "prompt", "store"]
+    },
+
+    "explanation": {
+      "properties": {
+        "id": {"type": "string"},
+        "type": { "enum": ["explanation"] },
+        "title": {"type": "string"},
+        "prompt": { "$ref": "#/definitions/prompt"},
         "skip_logic": {"type": ["string", "null"]}
       },
       "additionalProperties": false,
-      "required": ["id", "type", "title", "prompt"]
+      "required": ["id", "type", "title", "prompt", "skip_logic"]
     },
+
+    "language-selection": {
+      "properties": {
+        "id": {"type": "string"},
+        "type": { "enum": ["language-selection"] },
+        "title": {"type": "string"},
+        "prompt": { "$ref": "#/definitions/lang_prompt"},
+        "language_choices": { "type": "array" },
+        "store": { "type": "string" }
+      },
+      "additionalProperties": false,
+      "required": ["id", "type", "title", "prompt", "language_choices", "store"]
+    },
+
     "choices": {
       "type": "array",
       "items": {
@@ -61,6 +106,7 @@
         "$ref": "#/definitions/range"
       }
     },
+
     "range": {
       "properties": {
         "from": {"type": ["integer", "null"]},
@@ -76,11 +122,13 @@
         "sms": {
           "type": "object",
           "additionalProperties": {
-            "type": "array"
+            "type": "array",
+            "items": { "type": "string" }
           }
         },
         "ivr": {
-          "type": "array"
+          "type": "array",
+          "items": { "type": "string" }
         }
       }
     },
@@ -94,12 +142,12 @@
       "type": "object",
       "properties": {
         "sms": {"type": "string" },
-        "ivr": {"$ref": "#/definitions/ivr"}
+        "ivr": {"$ref": "#/definitions/ivr_prompt"}
       },
       "additionalProperties": false
     },
 
-    "ivr": {
+    "ivr_prompt": {
       "type": "object",
       "properties": {
         "text": {"type": "string"},

--- a/test/lib/json_schema_test.exs
+++ b/test/lib/json_schema_test.exs
@@ -40,8 +40,8 @@ defmodule Ask.StepsValidatorTest do
   defp valid_lang_prompt(json), do: valid_thing(json, :lang_prompt)
   defp invalid_lang_prompt(json, case_desc), do: invalid_thing(json, :lang_prompt, case_desc)
 
-  defp valid_ivr(json), do: valid_thing(json, :ivr)
-  defp invalid_ivr(json, case_desc), do: invalid_thing(json, :ivr, case_desc)
+  defp valid_ivr(json), do: valid_thing(json, :ivr_prompt)
+  defp invalid_ivr(json, case_desc), do: invalid_thing(json, :ivr_prompt, case_desc)
 
   defp valid_choice(json), do: valid_thing(json, :choice)
   defp invalid_choice(json, case_desc), do: invalid_thing(json, :choice, case_desc)
@@ -142,7 +142,7 @@ defmodule Ask.StepsValidatorTest do
       "type": "language-selection",
       "prompt": {},
       "store": "",
-      "choices": ["en", "fr", "es"]
+      "language_choices": [null, "en", "fr", "es"]
     })
     |> valid_step
 
@@ -154,6 +154,16 @@ defmodule Ask.StepsValidatorTest do
       "prompt": {},
       "store": "Smokes",
       "choices": []
+    })
+    |> valid_step
+
+    ~s(
+    {
+      "id": "9616feb6-33c0-4feb-8aa8-84ba9a607103",
+      "title": "Explanation",
+      "type": "explanation",
+      "prompt": {},
+      "skip_logic": null
     })
     |> valid_step
   end


### PR DESCRIPTION
I added definitions for each step type so not every attribute is allowed on all steps.

The problem with this is that error messages becomes more cryptic (almost unusable). That's why I refrained from committing this into master directly and send a PR instead. I'd like to hear other's opinions.

Also, when I ran the validation against my dev database (`mix ask.validate_json_in_db`) I got a lot of errors I had to manually fix (mostly badly generated questionnaires from old ages).