### PR TITLE
[Quiz] Implement refusal for numeric steps. Fixes #587

### DIFF
--- a/lib/ask/runtime/flow.ex
+++ b/lib/ask/runtime/flow.ex
@@ -37,16 +37,29 @@ defmodule Ask.Runtime.Flow do
     end
   end
 
+  defp has_refusal_option(%{"refusal" => refusal = %{"enabled" => true}}, flow, reply) do
+    fetch(:response, flow, refusal)
+    |> Enum.any?(fn r -> (r |> clean_string) == reply end)
+  end
+
+  defp has_refusal_option(_, _, _) do
+    false
+  end
+
   defp next_step_by_skip_logic(flow, step, reply_value) do
     skip_logic =
       case step["type"] do
         "numeric" ->
-          value = String.to_integer(reply_value)
-          step["ranges"]
-          |> Enum.find_value(nil, fn (range) ->
-            if (range["from"] == nil || range["from"] <= value) && (range["to"]
-              == nil || range["to"] >= value), do: range["skip_logic"], else: false
-          end)
+          if is_numeric(reply_value) do
+            value = String.to_integer(reply_value)
+            step["ranges"]
+            |> Enum.find_value(nil, fn (range) ->
+              if (range["from"] == nil || range["from"] <= value) && (range["to"]
+                == nil || range["to"] >= value), do: range["skip_logic"], else: false
+            end)
+          else
+            step["refusal"]["skip_logic"]
+          end
         "multiple-choice" ->
           step
           |> Map.get("choices")
@@ -120,7 +133,11 @@ defmodule Ask.Runtime.Flow do
                       end)
                       if (choice), do: choice["value"], else: nil
                     "numeric" ->
-                      if (is_numeric(reply)), do: reply, else: nil
+                      if is_numeric(reply) || has_refusal_option(step, flow, reply) do
+                        reply
+                      else
+                        nil
+                      end
                     "language-selection" ->
                       choices = step["language_choices"]
                       {num, ""} = Integer.parse(reply)
@@ -137,15 +154,10 @@ defmodule Ask.Runtime.Flow do
 
     case reply_value do
       nil ->
-        if reply == "*" do
-          flow = flow |> advance_current_step(step, reply_value)
-          {%{flow | retries: 0}, %Reply{}}
+        if flow.retries >=  @max_retries do
+          {%{flow | current_step: flow |> end_flow}, %Reply{}}
         else
-          if flow.retries >=  @max_retries do
-            {%{flow | current_step: flow |> end_flow}, %Reply{}}
-          else
-            {%{flow | retries: flow.retries + 1}, %Reply{prompts: [fetch(:error_msg, flow, step)]}}
-          end
+          {%{flow | retries: flow.retries + 1}, %Reply{prompts: [fetch(:error_msg, flow, step)]}}
         end
       reply_value ->
         flow = flow |> advance_current_step(step, reply_value)

--- a/priv/schema.json
+++ b/priv/schema.json
@@ -55,10 +55,22 @@
         "max_value": {"type": ["integer", "null"]},
         "ranges_delimiters": {"type": ["string", "null"]},
         "ranges": {"$ref": "#/definitions/ranges"},
-        "store": { "type": "string" }
+        "store": { "type": "string" },
+        "refusal": { "oneOf": [{ "$ref": "#/definitions/refusal" }, {"type":"null"}] }
       },
       "additionalProperties": false,
       "required": ["id", "type", "title", "prompt", "store"]
+    },
+
+    "refusal": {
+      "type": "object",
+      "properties": {
+        "enabled": {"type": "boolean"},
+        "responses": {"$ref": "#/definitions/responses"},
+        "skip_logic": {"type": ["string", "null"]}
+      },
+      "additionalProperties": false,
+      "required": ["enabled", "responses", "skip_logic"]
     },
 
     "explanation": {

--- a/test/support/dummy_steps.ex
+++ b/test/support/dummy_steps.ex
@@ -11,13 +11,14 @@ defmodule Ask.StepBuilder do
   end
 
   def numeric_step(id: id, title: title, prompt: prompt, store: store,
-    skip_logic: skip_logic) do
+    skip_logic: skip_logic, refusal: refusal) do
     base = %{
       "id" => id,
       "type" => "numeric",
       "title" => title,
       "prompt" => prompt,
       "store" => store,
+      "refusal" => refusal,
     }
     Map.merge(base, skip_logic)
   end
@@ -198,7 +199,8 @@ defmodule Ask.DummySteps do
           title: "Which is the second perfect number?",
           prompt: prompt(sms: sms_prompt("Which is the second perfect number??")),
           store: "Perfect Number",
-          skip_logic: default_numeric_skip_logic()
+          skip_logic: default_numeric_skip_logic(),
+          refusal: nil
         ),
         flag_step(
           id: "aaa",
@@ -215,7 +217,8 @@ defmodule Ask.DummySteps do
           title: "What's the number of this question?",
           prompt: prompt(sms: sms_prompt("What's the number of this question??")),
           store: "Question",
-          skip_logic: default_numeric_skip_logic()
+          skip_logic: default_numeric_skip_logic(),
+          refusal: nil
         )
       ]
 
@@ -251,14 +254,16 @@ defmodule Ask.DummySteps do
           title: "Which is the second perfect number?",
           prompt: prompt(sms: sms_prompt("Which is the second perfect number??")),
           store: "Perfect Number",
-          skip_logic: default_numeric_skip_logic()
+          skip_logic: default_numeric_skip_logic(),
+          refusal: nil
         ),
         numeric_step(
           id: Ecto.UUID.generate,
           title: "What's the number of this question?",
           prompt: prompt(sms: sms_prompt("What's the number of this question??")),
           store: "Question",
-          skip_logic: default_numeric_skip_logic()
+          skip_logic: default_numeric_skip_logic(),
+          refusal: nil
         )
       ]
 
@@ -329,7 +334,8 @@ defmodule Ask.DummySteps do
                   "skip_logic" => "end"
                 }
               ]
-            )
+            ),
+            refusal: nil
           ),
           multiple_choice_step(
             id: "eee",

--- a/web/static/js/actions/questionnaire.js
+++ b/web/static/js/actions/questionnaire.js
@@ -37,6 +37,8 @@ export const CHANGE_RANGE_SKIP_LOGIC = 'QUESTIONNAIRE_CHANGE_RANGE_SKIP_LOGIC'
 export const UPLOAD_CSV_FOR_TRANSLATION = 'QUESTIONNAIRE_UPLOAD_CSV_FOR_TRANSLATION'
 export const CHANGE_EXPLANATION_STEP_SKIP_LOGIC = 'QUESTIONNAIRE_CHANGE_EXPLANATION_STEP_SKIP_LOGIC'
 export const CHANGE_DISPOSITION = 'QUESTIONNAIRE_CHANGE_DISPOSITION'
+export const TOGGLE_ACCEPT_REFUSALS = 'QUESTIONNAIRE_TOGGLE_ACCEPT_REFUSALS'
+export const CHANGE_REFUSAL = 'QUESTIONNAIRE_CHANGE_REFUSAL'
 
 export const fetchQuestionnaire = (projectId, id) => (dispatch, getState) => {
   dispatch(fetch(projectId, id))
@@ -304,4 +306,17 @@ export const changeDisposition = (stepId, disposition) => ({
   type: CHANGE_DISPOSITION,
   stepId,
   disposition
+})
+
+export const toggleAcceptsRefusals = (stepId) => ({
+  type: TOGGLE_ACCEPT_REFUSALS,
+  stepId
+})
+
+export const changeRefusal = (stepId, smsValues, ivrValues, skipLogic) => ({
+  type: CHANGE_REFUSAL,
+  stepId,
+  smsValues,
+  ivrValues,
+  skipLogic
 })

--- a/web/static/js/components/questionnaires/ChoiceEditor.jsx
+++ b/web/static/js/components/questionnaires/ChoiceEditor.jsx
@@ -10,7 +10,7 @@ type Props = {
   onDelete: Function,
   onChoiceChange: Function,
   choice: Choice,
-  choiceIndex: number,
+  choiceIndex: any,
   readOnly: boolean,
   stepIndex: number,
   stepsBefore: Step[],
@@ -183,6 +183,8 @@ class ChoiceEditor extends Component {
   render() {
     const { onDelete, stepIndex, stepsBefore, stepsAfter, readOnly, choiceIndex, sms, ivr, errors, lang, smsAutocompleteGetData, smsAutocompleteOnSelect } = this.props
 
+    const isRefusal = choiceIndex == 'refusal'
+
     let skipLogicInput =
       <td>
         <SkipLogic
@@ -197,7 +199,8 @@ class ChoiceEditor extends Component {
     if (this.state.editing) {
       return (
         <tr>
-          <td onMouseDown={e => this.setDoNotClose('response')}>
+          {!isRefusal
+          ? <td onMouseDown={e => this.setDoNotClose('response')}>
             <input
               type='text'
               placeholder='Response'
@@ -207,6 +210,7 @@ class ChoiceEditor extends Component {
               onBlur={e => this.autoComplete(e)}
               onKeyDown={(e: Event) => this.onKeyDown(e, 'sms', true)} />
           </td>
+          : null }
           { sms
           ? <td onMouseDown={e => this.setDoNotClose('sms')}>
             <input
@@ -244,17 +248,20 @@ class ChoiceEditor extends Component {
           </td>
         </tr>)
     } else {
-      let responseErrors = errors[choiceValuePath(stepIndex, choiceIndex)]
+      let responseErrors = !isRefusal ? errors[choiceValuePath(stepIndex, choiceIndex)] : null
       let smsErrors = errors[choiceSmsResponsePath(stepIndex, choiceIndex, lang)]
       let ivrErrors = errors[choiceIvrResponsePath(stepIndex, choiceIndex)]
 
       return (
         <tr>
-          {this.cell(this.state.response, 'No response', responseErrors, true, e => this.enterEditMode(e, 'response'))}
+          {!isRefusal && responseErrors
+          ? this.cell(this.state.response, 'No response', responseErrors, true, e => this.enterEditMode(e, 'response'))
+          : null
+          }
           {this.cell(this.state.sms, 'No SMS', smsErrors, sms, e => this.enterEditMode(e, 'sms'))}
           {this.cell(this.state.ivr, 'No IVR', ivrErrors, ivr, e => this.enterEditMode(e, 'ivr'))}
           {skipLogicInput}
-          { readOnly ? <td />
+          { readOnly || isRefusal ? <td />
             : <td>
               <a href='#!' onClick={onDelete}><i className='material-icons grey-text'>delete</i></a>
             </td>

--- a/web/static/js/components/questionnaires/NumericStepEditor.jsx
+++ b/web/static/js/components/questionnaires/NumericStepEditor.jsx
@@ -75,8 +75,11 @@ class NumericStepEditor extends Component {
                   questionnaire={questionnaire}
                   readOnly={readOnly}
                   step={step}
+                  stepIndex={stepIndex}
                   stepsAfter={stepsAfter}
-                  stepsBefore={stepsBefore} />
+                  stepsBefore={stepsBefore}
+                  errors={errors}
+                  />
               </div>
             </div>
           </li>

--- a/web/static/js/decls/questionnaire.js
+++ b/web/static/js/decls/questionnaire.js
@@ -58,7 +58,19 @@ export type NumericStep = BaseStep & StoreStep & MultilingualStep & {
   maxValue: ?number,
   rangesDelimiters: ?string,
   ranges: Range[],
+  refusal: ?Refusal
 };
+
+export type Refusal = {
+  enabled: boolean,
+  responses: {
+    ivr?: string[],
+    sms?: {
+      [lang: string]: string[]
+    }
+  },
+  skipLogic: ?string
+}
 
 export type Range = {
   from: ?number,

--- a/web/static/js/step.js
+++ b/web/static/js/step.js
@@ -79,3 +79,15 @@ export const newIvrPrompt = () => ({
   text: '',
   audioSource: 'tts'
 })
+
+export const newRefusal = () => ({
+  enabled: false,
+  responses: {
+    ivr: [],
+    sms: {
+      'en': []
+    }
+  },
+  skipLogic: null
+})
+


### PR DESCRIPTION
It works, both in the UI and the backend. Some notes:

* It reuses the ChoiceEditor component because it's almost the same. The difference is that there's no "value" field, and there's no "delete" button. Right now this is done by passing `chocieIndex='refusal'` to it, maybe we can later find a better way.
* Missing are validations and autocomplete. This can also be done in the future.
* Any key can be used for the IVR prompt, this is not restricted to `*` and `#` (this probably is another validation and falls in the above point)

We can open separate, smaller issues to tackle the above points.