### PR TITLE
Prevent input text from being changed when props remain the same. Fixes #717

### DIFF
--- a/web/static/js/components/questionnaires/ChoiceEditor.jsx
+++ b/web/static/js/components/questionnaires/ChoiceEditor.jsx
@@ -5,6 +5,7 @@ import classNames from 'classnames/bind'
 import SkipLogic from './SkipLogic'
 import { getChoiceResponseSmsJoined, getChoiceResponseIvrJoined } from '../../step'
 import { choiceValuePath, choiceSmsResponsePath, choiceIvrResponsePath } from '../../questionnaireErrors'
+import propsAreEqual from '../../propsAreEqual'
 
 type Props = {
   onDelete: Function,
@@ -74,6 +75,8 @@ class ChoiceEditor extends Component {
   }
 
   componentWillReceiveProps(newProps: Props) {
+    if (propsAreEqual(this.props, newProps)) return
+
     let newState = this.stateFromProps(newProps)
     this.setState({ ...newState, editing: this.state.editing })
   }

--- a/web/static/js/components/questionnaires/ExplanationStepEditor.jsx
+++ b/web/static/js/components/questionnaires/ExplanationStepEditor.jsx
@@ -9,6 +9,7 @@ import StepCard from './StepCard'
 import DraggableStep from './DraggableStep'
 import StepDeleteButton from './StepDeleteButton'
 import SkipLogic from './SkipLogic'
+import propsAreEqual from '../../propsAreEqual'
 
 type Props = {
   step: ExplanationStep,
@@ -41,6 +42,8 @@ class ExplanationStepEditor extends Component {
   }
 
   componentWillReceiveProps(newProps) {
+    if (propsAreEqual(this.props, newProps)) return
+
     this.setState(this.stateFromProps(newProps))
   }
 

--- a/web/static/js/components/questionnaires/FlagStepEditor.jsx
+++ b/web/static/js/components/questionnaires/FlagStepEditor.jsx
@@ -8,6 +8,7 @@ import StepCard from './StepCard'
 import DraggableStep from './DraggableStep'
 import StepDeleteButton from './StepDeleteButton'
 import SkipLogic from './SkipLogic'
+import propsAreEqual from '../../propsAreEqual'
 
 type Props = {
   step: FlagStep,
@@ -39,6 +40,8 @@ class FlagStepEditor extends Component {
   }
 
   componentWillReceiveProps(newProps) {
+    if (propsAreEqual(this.props, newProps)) return
+
     this.setState(this.stateFromProps(newProps))
   }
 

--- a/web/static/js/components/questionnaires/IvrPrompt.jsx
+++ b/web/static/js/components/questionnaires/IvrPrompt.jsx
@@ -5,6 +5,7 @@ import { InputWithLabel, ConfirmationModal, AudioDropzone, Dropdown, DropdownIte
 import { createAudio } from '../../api.js'
 import * as questionnaireActions from '../../actions/questionnaire'
 import classNames from 'classnames/bind'
+import propsAreEqual from '../../propsAreEqual'
 
 type State = {
   audioErrors: string,
@@ -58,6 +59,8 @@ class IvrPrompt extends Component {
   }
 
   componentWillReceiveProps(newProps) {
+    if (propsAreEqual(this.props, newProps)) return
+
     this.setState(this.stateFromProps(newProps))
   }
 

--- a/web/static/js/components/questionnaires/LanguageSelectionStepEditor.jsx
+++ b/web/static/js/components/questionnaires/LanguageSelectionStepEditor.jsx
@@ -9,6 +9,7 @@ import StepLanguageSelection from './StepLanguageSelection'
 import DraggableStep from './DraggableStep'
 import StepStoreVariable from './StepStoreVariable'
 import { getStepPromptSms, getStepPromptIvrText } from '../../step'
+import propsAreEqual from '../../propsAreEqual'
 
 type Props = {
   step: LanguageSelectionStep,
@@ -38,6 +39,8 @@ class LanguageSelectionStepEditor extends Component {
   }
 
   componentWillReceiveProps(newProps) {
+    if (propsAreEqual(this.props, newProps)) return
+
     this.setState(this.stateFromProps(newProps))
   }
 

--- a/web/static/js/components/questionnaires/MultipleChoiceStepEditor.jsx
+++ b/web/static/js/components/questionnaires/MultipleChoiceStepEditor.jsx
@@ -11,6 +11,7 @@ import DraggableStep from './DraggableStep'
 import StepDeleteButton from './StepDeleteButton'
 import StepStoreVariable from './StepStoreVariable'
 import { getStepPromptSms, getStepPromptIvrText } from '../../step'
+import propsAreEqual from '../../propsAreEqual'
 
 type Props = {
   step: MultipleChoiceStep,
@@ -42,6 +43,8 @@ class MultipleChoiceStepEditor extends Component {
   }
 
   componentWillReceiveProps(newProps) {
+    if (propsAreEqual(this.props, newProps)) return
+
     this.setState(this.stateFromProps(newProps))
   }
 

--- a/web/static/js/components/questionnaires/NumericStepEditor.jsx
+++ b/web/static/js/components/questionnaires/NumericStepEditor.jsx
@@ -11,6 +11,7 @@ import DraggableStep from './DraggableStep'
 import StepDeleteButton from './StepDeleteButton'
 import StepStoreVariable from './StepStoreVariable'
 import { getStepPromptSms, getStepPromptIvrText } from '../../step'
+import propsAreEqual from '../../propsAreEqual'
 
 type Props = {
   step: NumericStep,
@@ -42,6 +43,8 @@ class NumericStepEditor extends Component {
   }
 
   componentWillReceiveProps(newProps) {
+    if (propsAreEqual(this.props, newProps)) return
+
     this.setState(this.stateFromProps(newProps))
   }
 

--- a/web/static/js/components/questionnaires/QuestionnaireMsg.jsx
+++ b/web/static/js/components/questionnaires/QuestionnaireMsg.jsx
@@ -11,6 +11,7 @@ import { decamelize } from 'humps'
 import { getPromptSms, getPromptIvr, getPromptIvrText } from '../../step'
 import { msgPromptTextPath, msgHasErrors } from '../../questionnaireErrors'
 import * as api from '../../api'
+import propsAreEqual from '../../propsAreEqual'
 
 type Props = {
   dispatch: Function,
@@ -102,6 +103,8 @@ class QuestionnaireMsg extends Component {
   }
 
   componentWillReceiveProps(newProps) {
+    if (propsAreEqual(this.props, newProps)) return
+
     this.setState(this.stateFromProps(newProps, this.state.editing))
   }
 

--- a/web/static/js/components/questionnaires/SkipLogic.jsx
+++ b/web/static/js/components/questionnaires/SkipLogic.jsx
@@ -2,6 +2,7 @@
 import findIndex from 'lodash/findIndex'
 import React, { Component } from 'react'
 import { Input } from 'react-materialize'
+import propsAreEqual from '../../propsAreEqual'
 
 type Props = {
   value: ?string,
@@ -26,6 +27,8 @@ class SkipLogic extends Component {
   }
 
   componentWillReceiveProps(newProps: Props) {
+    if (propsAreEqual(this.props, newProps)) return
+
     this.setState(this.stateFromProps(newProps))
   }
 

--- a/web/static/js/components/questionnaires/StepNumericEditor.jsx
+++ b/web/static/js/components/questionnaires/StepNumericEditor.jsx
@@ -7,6 +7,7 @@ import * as questionnaireActions from '../../actions/questionnaire'
 import { newRefusal } from '../../step'
 import ChoiceEditor from './ChoiceEditor'
 import SkipLogic from './SkipLogic'
+import propsAreEqual from '../../propsAreEqual'
 
 type State = {
   stepId: string,
@@ -35,8 +36,10 @@ class StepNumericEditor extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState(this.stateFromProps(nextProps))
+  componentWillReceiveProps(newProps) {
+    if (propsAreEqual(this.props, newProps)) return
+
+    this.setState(this.stateFromProps(newProps))
   }
 
   delimitersFromRanges(ranges) {

--- a/web/static/js/components/questionnaires/StepPrompts.jsx
+++ b/web/static/js/components/questionnaires/StepPrompts.jsx
@@ -8,6 +8,7 @@ import IvrPrompt from './IvrPrompt'
 import { getStepPromptSms, getStepPromptIvr, getStepPromptIvrText } from '../../step'
 import { promptTextPath } from '../../questionnaireErrors'
 import * as api from '../../api'
+import propsAreEqual from '../../propsAreEqual'
 
 type State = {
   stepPromptSms: string,
@@ -71,6 +72,8 @@ class StepPrompts extends Component {
   }
 
   componentWillReceiveProps(newProps) {
+    if (propsAreEqual(this.props, newProps)) return
+
     this.setState(this.stateFromProps(newProps))
   }
 

--- a/web/static/js/components/questionnaires/StepStoreVariable.jsx
+++ b/web/static/js/components/questionnaires/StepStoreVariable.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux'
 import { Autocomplete } from '../ui'
 import * as questionnaireActions from '../../actions/questionnaire'
 import * as api from '../../api.js'
+import propsAreEqual from '../../propsAreEqual'
 
 type Props = {
   step: StoreStep & BaseStep,
@@ -42,6 +43,8 @@ class StepStoreVariable extends Component {
   }
 
   componentWillReceiveProps(newProps) {
+    if (propsAreEqual(this.props, newProps)) return
+
     this.setState(this.stateFromProps(newProps))
   }
 

--- a/web/static/js/propsAreEqual.js
+++ b/web/static/js/propsAreEqual.js
@@ -1,0 +1,21 @@
+import pickBy from 'lodash/pickBy'
+import isEqual from 'lodash/isEqual'
+
+/**
+ * Compare two props objects to see if they are deeply equal,
+ * ignoring any properties that are functions. Useful in
+ * `componentWillReceiveProps` to skip setting state from props
+ * that are essentially the same, avoiding a re-render and
+ * solving an issue that would overwrite values while a user
+ * was typing.
+ */
+export default function propsAreEqual(oldProps, newProps) {
+  oldProps = pickBy(oldProps, isNotAFunction)
+  newProps = pickBy(newProps, isNotAFunction)
+
+  return isEqual(oldProps, newProps)
+}
+
+function isNotAFunction(value, key) {
+  return typeof (value) != 'function'
+}


### PR DESCRIPTION
The main issue that causes this is that a SAVE action is fired asynchronously after some time, and when that happens a component's state is re-hydrated from the new props. If the user was typing something in a text input, this state change overwrites the value.

This PR fixes this by not re-hydrating the state from the new props if these new props are the same as the old props. At first I used `lodash/isEqual` for this, but it doesn't work all the time because some properties are functions (`onClick`, `onChange`, etc.) that, if not bound with `bind`, change on each re-render. One way to fix this is to use `bind`, but this isn't always possible because some functions are created in a loop and depend on an index. So, a solution is to simply ignore key/values in props that are functions. This is OK to do because a component's state hydrated from props always uses properties like strings, arrays, etc., never functions.

We could eventually come up with a better solution, but for now this overwrite issue is pretty annoying and fixing it now will greatly improve usability.