### PR TITLE
Support HTTPs

### DIFF
--- a/lib/ask/endpoint.ex
+++ b/lib/ask/endpoint.ex
@@ -5,6 +5,14 @@ defmodule Ask.Endpoint do
 
   plug Ask.Static
 
+  IO.puts "Checking to enable SSL"
+  if System.get_env("SSL") && System.get_env("SSL") != "0" do
+    IO.puts "Starting with SSL"
+    plug Plug.SSL, rewrite_on: [:x_forwarded_proto]
+  else
+    IO.puts "Starting without SSL"
+  end
+
   # Code reloading can be explicitly enabled under the
   # :code_reloader configuration of your endpoint.
   if code_reloading? do

--- a/web/controllers/oauth_client_controller.ex
+++ b/web/controllers/oauth_client_controller.ex
@@ -53,19 +53,24 @@ defmodule Ask.OAuthClientController do
     user = get_current_user(conn)
     token = user |> assoc(:oauth_tokens) |> Repo.get_by(provider: provider_name, base_url: base_url)
 
-    if token == nil do
+    error = if token == nil do
       provider = Ask.Channel.provider(provider_name)
       access_token = provider.oauth2_authorize(code, "#{url(conn)}#{conn.request_path}", base_url)
 
-      user
-      |> build_assoc(:oauth_tokens, provider: provider_name, base_url: base_url)
-      |> Ask.OAuthToken.from_access_token(access_token)
-      |> Repo.insert!
+      if access_token.other_params && access_token.other_params["error"] do
+        access_token.other_params["error_description"] || "Error connecting to provider: #{access_token.other_params["error"]}"
+      else
+        user
+        |> build_assoc(:oauth_tokens, provider: provider_name, base_url: base_url)
+        |> Ask.OAuthToken.from_access_token(access_token)
+        |> Repo.insert!
 
-      provider.sync_channels(user.id, base_url)
+        provider.sync_channels(user.id, base_url)
+        nil
+      end
     end
 
-    render conn, "callback.html"
+    render conn, "callback.html", error: error
   end
 
   def callback(conn, _params) do

--- a/web/controllers/oauth_client_controller.ex
+++ b/web/controllers/oauth_client_controller.ex
@@ -55,7 +55,8 @@ defmodule Ask.OAuthClientController do
 
     error = if token == nil do
       provider = Ask.Channel.provider(provider_name)
-      access_token = provider.oauth2_authorize(code, "#{url(conn)}#{conn.request_path}", base_url)
+      url = %URI{scheme: conn.scheme |> Atom.to_string, host: conn.host, path: conn.request_path} |> URI.to_string
+      access_token = provider.oauth2_authorize(code, url, base_url)
 
       if access_token.other_params && access_token.other_params["error"] do
         access_token.other_params["error_description"] || "Error connecting to provider: #{access_token.other_params["error"]}"

--- a/web/static/js/actions/authorizations.js
+++ b/web/static/js/actions/authorizations.js
@@ -69,8 +69,12 @@ export const toggleAuthorization = (provider, index) => (dispatch, getState) => 
     return guissoSession.authorize('code', provider, baseUrl)
       .then(() => guissoSession.close())
       .then(() => { dispatch(channelActions.fetchChannels()) })
-      .catch(() => {
+      .catch((err) => {
+        guissoSession.close()
         dispatch(deleteAuthorization(provider, baseUrl))
+        if (err) {
+          throw err
+        }
       })
   }
 }

--- a/web/static/js/guisso.js
+++ b/web/static/js/guisso.js
@@ -45,9 +45,14 @@ class GuissoSession {
       const listener = function(event) {
         if (event.source == popup) {
           window.removeEventListener('message', listener)
-          const token = queryString.parse(event.data)
           window.clearInterval(watchdog)
-          resolve(token)
+          if (event.data.error && event.data.error.length > 0) {
+            console.log(event.data)
+            reject(event.data.error)
+          } else {
+            const token = queryString.parse(event.data)
+            resolve(token)
+          }
         }
       }
       window.addEventListener('message', listener, false)

--- a/web/templates/o_auth_client/callback.html.eex
+++ b/web/templates/o_auth_client/callback.html.eex
@@ -1,7 +1,7 @@
 <html>
 <head>
 <script type="text/javascript">
-  window.opener.postMessage(window.location.hash, "*");
+  window.opener.postMessage({token: window.location.hash, error: "<%= if(@error, do: @error, else: "") %>"}, "*");
 </script>
 </head>
 </html>


### PR DESCRIPTION
- Properly handle OAuth errors in channels page
- Use request's scheme and header as OAuth redirect URI in channels page
- Force SSL and honour X-Forwarded-Proto header if SSL env var is set

Fixes #693
Connects to #693