### PR TITLE
For #721. Change font size for options depending on number of characters

### DIFF
--- a/web/static/mobile_survey/css/mobile.scss
+++ b/web/static/mobile_survey/css/mobile.scss
@@ -57,6 +57,21 @@ main {
 h1 {
   font-size: 1.3rem;
   line-height: 1.4;
+  &.prompt-length-less-100{
+    font-size: 1.3rem;
+  }
+  &.prompt-length-less-200{
+    font-size: 1.1rem;
+  }
+  &.prompt-length-less-300{
+    font-size: 0.9rem;
+  }
+  &.prompt-length-less-400{
+    font-size: 0.7rem;
+  }
+  &.prompt-length-large{
+    font-size: 0.5rem;
+  }
 }
 .btn {
   display: inline-block;
@@ -125,4 +140,30 @@ select {
     clear: both;
     zoom: 1;
   }
+}
+
+// FONT-SIZE related with buttons of multiple choice steps
+
+.choice-length-less-7{
+  font-size: 1.6rem;
+}
+
+.choice-length-less-14{
+  font-size: 1.4rem;
+}
+
+.choice-length-less-20{
+  font-size: 1.2rem;
+}
+
+.choice-length-less-40{
+  font-size: 1.0rem;
+}
+
+.choice-length-less-60{
+  font-size: 0.8rem;
+}
+
+.choice-length-large{
+  font-size: 0.6rem;
 }

--- a/web/static/mobile_survey/js/components/Prompt.jsx
+++ b/web/static/mobile_survey/js/components/Prompt.jsx
@@ -2,9 +2,31 @@
 import React, { Component, PropTypes } from 'react'
 
 class Prompt extends Component {
+  classNameForPrompt(prompt: String) {
+    const length = prompt.length
+    let cssClass
+    switch (true) {
+      case (length < 100):
+        cssClass = 'prompt-length-less-100'
+        break
+      case (length < 200):
+        cssClass = 'prompt-length-less-200'
+        break
+      case (length < 300):
+        cssClass = 'prompt-length-less-300'
+        break
+      case (length < 400):
+        cssClass = 'prompt-length-less-400'
+        break
+      default:
+        cssClass = 'prompt-length-large'
+    }
+    return cssClass
+  }
+
   render() {
     const { text } = this.props
-    return <div className='prompt'><h1>{text}</h1></div>
+    return <div className={'prompt'}><h1 className={this.classNameForPrompt(text)}>{text}</h1></div>
   }
 }
 
@@ -13,4 +35,3 @@ Prompt.propTypes = {
 }
 
 export default Prompt
-

--- a/web/static/mobile_survey/js/components/steps/MultipleChoiceStep.jsx
+++ b/web/static/mobile_survey/js/components/steps/MultipleChoiceStep.jsx
@@ -7,6 +7,31 @@ class MultipleChoiceStep extends Component {
     return this.refs.select.value
   }
 
+  classNameForChoice(choice: String) {
+    const length = choice.length
+    let cssClass
+    switch (true) {
+      case (length < 4):
+        cssClass = 'choice-length-less-7'
+        break
+      case (length < 12):
+        cssClass = 'choice-length-less-14'
+        break
+      case (length < 20):
+        cssClass = 'choice-length-less-20'
+        break
+      case (length < 40):
+        cssClass = 'choice-length-less-40'
+        break
+      case (length < 60):
+        cssClass = 'choice-length-less-60'
+        break
+      default:
+        cssClass = 'choice-length-large'
+    }
+    return cssClass
+  }
+
   render() {
     const { step, onClick } = this.props
     return (
@@ -17,7 +42,7 @@ class MultipleChoiceStep extends Component {
         {step.choices.map(choice => {
           return (
             <div key={choice}>
-              <button className='btn block' value={choice} onClick={e => { e.preventDefault(); onClick(choice) }}>{choice}</button>
+              <button className={'btn block ' + this.classNameForChoice(choice[0])} value={choice} onClick={e => { e.preventDefault(); onClick(choice) }}>{choice}</button>
             </div>
           )
         })}
@@ -32,4 +57,3 @@ MultipleChoiceStep.propTypes = {
 }
 
 export default MultipleChoiceStep
-


### PR DESCRIPTION
Connects to #721 

Length options for choices were inspired by the invision mockup:
'YES'(3) - 'NO'(2) - 'NO, BUT I'VE BEEN TAKING MEDICATION FOR RAISED BLOOD PRESSURE BEFORE(68)'

It wouldn't be so strange thinking about an option of 60 characters long

Length options for prompt were inspired by the questionnaire used in Zambia and Morocco:
For example, Prompt for Introduction and Consent:

_This survey contains up to 20 questions on information that will be used to understand the health of the population. You will receive K10 talktime if you successfully complete the survey as compensation for your time spent to answer the questions. Info shared will be kept private and will never be connected to your name or any other personal information_ (355)

It wouldn't be so trange thinking about a prompt of 355 charactesr long
