### PR TITLE
Change quota completed message to steps. Fixes #822

### DIFF
--- a/priv/repo/migrations/20170508193540_add_questionnaire_quota_completed_steps.exs
+++ b/priv/repo/migrations/20170508193540_add_questionnaire_quota_completed_steps.exs
@@ -1,0 +1,9 @@
+defmodule Ask.Repo.Migrations.AddQuestionnaireQuotaCompletedSteps do
+  use Ecto.Migration
+
+  def change do
+    alter table(:questionnaires) do
+      add :quota_completed_steps, :longtext
+    end
+  end
+end

--- a/priv/repo/migrations/20170508193825_move_questionnaire_settings_quota_completed_message_to_quota_completed_steps.exs
+++ b/priv/repo/migrations/20170508193825_move_questionnaire_settings_quota_completed_message_to_quota_completed_steps.exs
@@ -1,0 +1,47 @@
+defmodule Ask.Repo.Migrations.MoveQuestionnaireSettingsQuotaCompletedMessageToQuotaCompletedSteps do
+  use Ecto.Migration
+
+  alias Ask.Repo
+
+  defmodule Questionnaire do
+    use Ask.Web, :model
+
+    schema "questionnaires" do
+      field :steps, Ask.Ecto.Type.JSON
+      field :quota_completed_steps, Ask.Ecto.Type.JSON
+      field :settings, Ask.Ecto.Type.JSON
+    end
+
+    def changeset(struct, params \\ %{}) do
+      struct
+      |> cast(params, [:steps, :quota_completed_steps, :settings])
+    end
+  end
+
+  def up do
+    Questionnaire |> Repo.all |> Enum.each(fn questionnaire ->
+      quota_completed_message = questionnaire.settings["quota_completed_message"]
+      quota_completed_steps =
+        if quota_completed_message do
+          [%{
+            "id" => Ecto.UUID.generate,
+            "prompt" => quota_completed_message,
+            "skip_logic" => nil,
+            "title" => "Quota completed message",
+            "type" => "explanation",
+            }]
+        else
+          nil
+        end
+
+      settings = Map.delete(questionnaire.settings, "quota_completed_message")
+
+      questionnaire
+      |> Questionnaire.changeset(%{settings: settings, quota_completed_steps: quota_completed_steps})
+      |> Repo.update!
+    end)
+  end
+
+  def down do
+  end
+end

--- a/priv/schema.json
+++ b/priv/schema.json
@@ -15,7 +15,6 @@
     "settings": {
       "type": "object",
       "properties": {
-        "quota_completed_message": {"oneOf": [{"$ref": "#/definitions/prompt"}, {"type":"null"}]},
         "error_message": {"oneOf": [{"$ref": "#/definitions/prompt"}, {"type":"null"}]},
         "mobile_web_sms_message": {"type": ["string", "null"]},
         "mobile_web_survey_is_over_message": {"type": ["string", "null"]},

--- a/test/js/fixtures.js
+++ b/test/js/fixtures.js
@@ -122,6 +122,7 @@ const bareQuestionnaire: Questionnaire = {
       }
     }
   ],
+  quotaCompletedSteps: null,
   projectId: 1,
   name: 'Foo',
   modes: [
@@ -132,7 +133,6 @@ const bareQuestionnaire: Questionnaire = {
   activeLanguage: 'en',
   languages: ['en'],
   settings: {
-    quotaCompletedMessage: {},
     errorMessage: {},
     mobileWebSmsMessage: '',
     mobileWebSurveyIsOverMessage: '',

--- a/test/js/reducers/questionnaire.spec.js
+++ b/test/js/reducers/questionnaire.spec.js
@@ -990,51 +990,6 @@ describe('questionnaire reducer', () => {
       })
     })
 
-    it('should validate quota completed message SMS prompt must not be blank if SMS mode is on', () => {
-      const state = playActions([
-        actions.fetch(1, 1),
-        actions.receive(questionnaire),
-        actions.setSmsQuestionnaireMsg('quotaCompletedMessage', '')
-      ])
-
-      expect(state.errors).toInclude({
-        path: `quotaCompletedMessage.prompt['en'].sms`,
-        lang: 'en',
-        mode: 'sms',
-        message: 'SMS prompt must not be blank'
-      })
-    })
-
-    it('should validate quota completed message Mobile Web prompt must not be blank if Mobile Web mode is on', () => {
-      const state = playActions([
-        actions.fetch(1, 1),
-        actions.receive(questionnaire),
-        actions.toggleMode('mobileweb')
-      ])
-
-      expect(state.errors).toInclude({
-        path: "quotaCompletedMessage.prompt['en'].mobileweb",
-        lang: 'en',
-        mode: 'mobileweb',
-        message: 'Mobile web prompt must not be blank'
-      })
-    })
-
-    it('should validate quota completed message IVR prompt must not be blank if IVR mode is on', () => {
-      const state = playActions([
-        actions.fetch(1, 1),
-        actions.receive(questionnaire),
-        actions.setSmsQuestionnaireMsg('quotaCompletedMessage', '')
-      ])
-
-      expect(state.errors).toInclude({
-        path: "quotaCompletedMessage.prompt['en'].ivr.text",
-        lang: 'en',
-        mode: 'ivr',
-        message: 'Voice prompt must not be blank'
-      })
-    })
-
     it('should consider "end" skip logic as valid', () => {
       const state = playActions([
         actions.fetch(1, 1),
@@ -1487,7 +1442,6 @@ describe('questionnaire reducer', () => {
         defaultLanguage: 'en',
         activeLanguage: 'en',
         settings: {
-          quotaCompletedMessage: {},
           errorMessage: {},
           mobileWebSmsMessage: '',
           mobileWebColorStyle: {},
@@ -1608,6 +1562,7 @@ describe('questionnaire reducer', () => {
             }
           }
         ],
+        quotaCompletedSteps: null,
         id: 1,
         valid: true
       }
@@ -1670,31 +1625,31 @@ describe('questionnaire reducer', () => {
   })
 
   describe('quotas', () => {
-    it('should set quota_completed_msg for the first time', () => {
+    it('should set errorMessage for the first time', () => {
       const smsText = '  Thanks for participating in the poll  '
       const ivrText = {text: '  Thank you very much  ', audioSource: 'tts'}
 
       const state = playActions([
         actions.fetch(1, 1),
         actions.receive(questionnaire),
-        actions.setSmsQuestionnaireMsg('quotaCompletedMessage', smsText),
-        actions.setIvrQuestionnaireMsg('quotaCompletedMessage', ivrText)
+        actions.setSmsQuestionnaireMsg('errorMessage', smsText),
+        actions.setIvrQuestionnaireMsg('errorMessage', ivrText)
       ])
 
-      expect(state.data.settings.quotaCompletedMessage['en']['sms']).toEqual(smsText.trim())
-      expect(state.data.settings.quotaCompletedMessage['en']['ivr']).toEqual({text: 'Thank you very much', audioSource: 'tts'})
+      expect(state.data.settings.errorMessage['en']['sms']).toEqual(smsText.trim())
+      expect(state.data.settings.errorMessage['en']['ivr']).toEqual({text: 'Thank you very much', audioSource: 'tts'})
     })
 
-    it('should set quota_completed_msg for mobile web', () => {
+    it('should set errorMessage for mobile web', () => {
       const mobilewebText = 'Thanks for participating in the poll'
 
       const state = playActions([
         actions.fetch(1, 1),
         actions.receive(questionnaire),
-        actions.setMobileWebQuestionnaireMsg('quotaCompletedMessage', mobilewebText)
+        actions.setMobileWebQuestionnaireMsg('errorMessage', mobilewebText)
       ])
 
-      expect(state.data.settings.quotaCompletedMessage['en']['mobileweb']).toEqual(mobilewebText)
+      expect(state.data.settings.errorMessage['en']['mobileweb']).toEqual(mobilewebText)
     })
 
     it('should set mobile web sms message', () => {
@@ -1721,8 +1676,8 @@ describe('questionnaire reducer', () => {
       expect(state.data.settings.mobileWebSurveyIsOverMessage).toEqual(mobileWebSurveyIsOverMessage)
     })
 
-    it('should not modify other mode quota message', () => {
-      const quotaMessage = {
+    it('should not modify other mode error message', () => {
+      const errorMessage = {
         'en': {
           'sms': 'thanks for answering sms',
           'ivr': { audioSource: 'tts', text: 'thanks for answering phone call' }
@@ -1733,7 +1688,7 @@ describe('questionnaire reducer', () => {
         ...questionnaire,
         settings: {
           ...questionnaire.settings,
-          quotaCompletedMessage: quotaMessage
+          errorMessage: errorMessage
         }
       }
 
@@ -1742,11 +1697,11 @@ describe('questionnaire reducer', () => {
       const state = playActions([
         actions.fetch(1, 1),
         actions.receive(q),
-        actions.setIvrQuestionnaireMsg('quotaCompletedMessage', newIvrText)
+        actions.setIvrQuestionnaireMsg('errorMessage', newIvrText)
       ])
 
-      expect(state.data.settings.quotaCompletedMessage['en']['sms']).toEqual('thanks for answering sms')
-      expect(state.data.settings.quotaCompletedMessage['en']['ivr']).toEqual(newIvrText)
+      expect(state.data.settings.errorMessage['en']['sms']).toEqual('thanks for answering sms')
+      expect(state.data.settings.errorMessage['en']['ivr']).toEqual(newIvrText)
     })
   })
 
@@ -1757,8 +1712,8 @@ describe('questionnaire reducer', () => {
         actions.receive(questionnaire),
         actions.addLanguage('fr'),
         actions.addLanguage('es'),
-        actions.setSmsQuestionnaireMsg('quotaCompletedMessage', 'Done'),
-        actions.setIvrQuestionnaireMsg('quotaCompletedMessage', {text: 'Done!', audioSource: 'tts'}),
+        actions.setSmsQuestionnaireMsg('errorMessage', 'Done'),
+        actions.setIvrQuestionnaireMsg('errorMessage', {text: 'Done!', audioSource: 'tts'}),
         actions.setDisplayedTitle('Some title'),
         actions.setSurveyAlreadyTakenMessage('Taken')
       ])
@@ -1784,14 +1739,14 @@ describe('questionnaire reducer', () => {
       expected.forEach((row, index) => expect(csv[index]).toEqual(row))
     })
 
-    it('should not duplicate sms and ivr quota completed msg (#421)', () => {
+    it('should not duplicate sms and ivr error msg (#421)', () => {
       const state = playActions([
         actions.fetch(1, 1),
         actions.receive(questionnaire),
         actions.addLanguage('fr'),
         actions.addLanguage('es'),
-        actions.setSmsQuestionnaireMsg('quotaCompletedMessage', 'Done'),
-        actions.setIvrQuestionnaireMsg('quotaCompletedMessage', {text: 'Done', audioSource: 'tts'})
+        actions.setSmsQuestionnaireMsg('errorMessage', 'Done'),
+        actions.setIvrQuestionnaireMsg('errorMessage', {text: 'Done', audioSource: 'tts'})
       ])
 
       const csv = csvForTranslation(state.data)
@@ -1843,13 +1798,13 @@ describe('questionnaire reducer', () => {
       expect(state.data.settings.surveyAlreadyTakenMessage.es).toEqual('Ya tomado')
     })
 
-    it('should upload csv with quota completed msg', () => {
+    it('should upload csv with error msg', () => {
       const state = playActions([
         actions.fetch(1, 1),
         actions.receive(questionnaire),
         actions.addLanguage('es'),
-        actions.setSmsQuestionnaireMsg('quotaCompletedMessage', 'Done'),
-        actions.setIvrQuestionnaireMsg('quotaCompletedMessage', {text: 'Done!', audioSource: 'tts'}),
+        actions.setSmsQuestionnaireMsg('errorMessage', 'Done'),
+        actions.setIvrQuestionnaireMsg('errorMessage', {text: 'Done!', audioSource: 'tts'}),
         actions.uploadCsvForTranslation(
           [
             ['English', 'Spanish'],
@@ -1862,16 +1817,16 @@ describe('questionnaire reducer', () => {
         )
       ])
 
-      expect(state.data.settings.quotaCompletedMessage.es.sms).toEqual('Listo')
-      expect(state.data.settings.quotaCompletedMessage.es.ivr).toEqual({text: 'Listo!', audioSource: 'tts'})
+      expect(state.data.settings.errorMessage.es.sms).toEqual('Listo')
+      expect(state.data.settings.errorMessage.es.ivr).toEqual({text: 'Listo!', audioSource: 'tts'})
     })
 
-    it('should upload csv with quota completed msg that lacks audioSource', () => {
+    it('should upload csv with error msg that lacks audioSource', () => {
       const state = playActions([
         actions.fetch(1, 1),
         actions.receive(questionnaire),
         actions.addLanguage('es'),
-        actions.setIvrQuestionnaireMsg('quotaCompletedMessage', {text: 'Done!', audioSource: 'tts'}),
+        actions.setIvrQuestionnaireMsg('errorMessage', {text: 'Done!', audioSource: 'tts'}),
         actions.uploadCsvForTranslation(
           [
             ['English', 'Spanish'],
@@ -1880,7 +1835,7 @@ describe('questionnaire reducer', () => {
         )
       ])
 
-      expect(state.data.settings.quotaCompletedMessage.es.ivr).toEqual({text: 'Listo!', audioSource: 'tts'})
+      expect(state.data.settings.errorMessage.es.ivr).toEqual({text: 'Listo!', audioSource: 'tts'})
     })
 
     it('should compute a valid alphanumeric filename', () => {

--- a/test/lib/runtime/broker_test.exs
+++ b/test/lib/runtime/broker_test.exs
@@ -1659,8 +1659,22 @@ defmodule Ask.BrokerTest do
     quiz = hd((survey |> Ask.Repo.preload(:questionnaires)).questionnaires)
     quiz
     |> Questionnaire.changeset(%{
+      quota_completed_steps: [%{
+        "id" => "quota-completed-step",
+        "type" => "explanation",
+        "title" => "Completed",
+        "prompt" => %{
+          "en" => %{
+            "sms" => "Quota completed",
+            "ivr" => %{
+              "audio_source" => "tts",
+              "text" => "Quota completed (ivr)"
+            }
+          }
+        },
+        "skip_logic" => nil
+      }],
       settings: %{
-        "quota_completed_message" => %{"en" => %{"sms" => "Bye!"}},
         "error_message" => %{"en" => %{"sms" => "Wrong answer"}}
       }
     })
@@ -1688,15 +1702,14 @@ defmodule Ask.BrokerTest do
     Broker.delivery_confirm(respondent, "Do you smoke?")
 
     reply = Broker.sync_step(respondent, Flow.Message.reply("No"))
-    assert {:end, {:reply, ReplyHelper.quota_completed("Bye!")}} = reply
+    assert {:end, {:reply, ReplyHelper.simple("Completed", "Quota completed")}} = reply
 
     respondent = Repo.get(Respondent, respondent.id)
-
-    Broker.delivery_confirm(respondent, "Quota completed")
+    Broker.delivery_confirm(respondent, "Completed")
 
     :ok = logger |> GenServer.stop
 
-    assert [do_you_smoke, foo, wrong_answer, do_you_smoke_again, dont_smoke, quota_completed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+    assert [do_you_smoke, foo, wrong_answer, do_you_smoke_again, dont_smoke] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
 
     assert do_you_smoke.survey_id == survey.id
     assert do_you_smoke.action_data == "Do you smoke?"
@@ -1717,10 +1730,6 @@ defmodule Ask.BrokerTest do
     assert dont_smoke.survey_id == survey.id
     assert dont_smoke.action_data == "No"
     assert dont_smoke.action_type == "response"
-
-    assert quota_completed.survey_id == survey.id
-    assert quota_completed.action_data == "Quota completed"
-    assert quota_completed.action_type == "prompt"
 
     :ok = broker |> GenServer.stop
   end
@@ -1753,8 +1762,22 @@ defmodule Ask.BrokerTest do
     quiz = hd((survey |> Ask.Repo.preload(:questionnaires)).questionnaires)
     quiz
     |> Questionnaire.changeset(%{
+      quota_completed_steps: [%{
+        "id" => "quota-completed-step",
+        "type" => "explanation",
+        "title" => "Completed",
+        "prompt" => %{
+          "en" => %{
+            "sms" => "Quota completed",
+            "ivr" => %{
+              "audio_source" => "tts",
+              "text" => "Quota completed (ivr)"
+            }
+          }
+        },
+        "skip_logic" => nil
+      }],
       settings: %{
-        "quota_completed_message" => %{"en" => %{"ivr" => "Bye!"}},
         "error_message" => %{"en" => %{"ivr" => %{"text" => "Wrong answer", "audio_source" => "tts"}}}
       }
     })
@@ -1779,11 +1802,11 @@ defmodule Ask.BrokerTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     reply = Broker.sync_step(respondent, Flow.Message.reply("9"))
-    assert {:end, {:reply, ReplyHelper.quota_completed_ivr("Bye!")}} = reply
+    assert {:end, {:reply, ReplyHelper.ivr("Completed", "Quota completed (ivr)")}} = reply
 
     :ok = logger |> GenServer.stop
 
-    assert [answer, do_you_smoke, foo, wrong_answer, do_you_smoke_again, dont_smoke, quota_completed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+    assert [answer, do_you_smoke, foo, wrong_answer, do_you_smoke_again, dont_smoke] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
 
     assert answer.survey_id == survey.id
     assert answer.action_data == "Answer"
@@ -1808,10 +1831,6 @@ defmodule Ask.BrokerTest do
     assert dont_smoke.survey_id == survey.id
     assert dont_smoke.action_data == "9"
     assert dont_smoke.action_type == "response"
-
-    assert quota_completed.survey_id == survey.id
-    assert quota_completed.action_data == "Quota completed"
-    assert quota_completed.action_type == "prompt"
 
     :ok = broker |> GenServer.stop
   end
@@ -2056,7 +2075,7 @@ defmodule Ask.BrokerTest do
 
     respondent = Repo.get(Respondent, respondent.id)
     reply = Broker.sync_step(respondent, Flow.Message.reply("Yes"))
-    assert {:end, {:reply, ReplyHelper.quota_completed("Quota completed")}} = reply
+    assert :end = reply
     updated_respondent = Repo.get(Respondent, respondent.id)
     assert updated_respondent.state == "rejected"
     assert updated_respondent.disposition == "rejected"
@@ -2430,7 +2449,7 @@ defmodule Ask.BrokerTest do
     end
 
     channel = insert(:channel, settings: test_channel |> TestChannel.settings, type: channel_type)
-    quiz = insert(:questionnaire, steps: steps)
+    quiz = insert(:questionnaire, steps: steps, quota_completed_steps: nil)
     survey = insert(:survey, Map.merge(@always_schedule, %{state: "running", questionnaires: [quiz], mode: [[mode]]}))
     group = insert(:respondent_group, survey: survey, respondents_count: 1) |> Repo.preload(:channels)
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -65,9 +65,11 @@ defmodule Ask.Factory do
       name: sequence(:questionnaire, &"Questionnaire #{&1}"),
       modes: ["sms", "ivr"],
       steps: [],
-      default_language: "en",
-      settings: %{
-        "quota_completed_message" => %{
+      quota_completed_steps: [%{
+        "id" => "quota-completed-step",
+        "type" => "explanation",
+        "title" => "Completed",
+        "prompt" => %{
           "en" => %{
             "sms" => "Quota completed",
             "ivr" => %{
@@ -76,6 +78,10 @@ defmodule Ask.Factory do
             }
           }
         },
+        "skip_logic" => nil
+      }],
+      default_language: "en",
+      settings: %{
         "error_message" => %{
           "en" => %{
             "sms" => "You have entered an invalid answer",

--- a/web/controllers/mobile_survey_controller.ex
+++ b/web/controllers/mobile_survey_controller.ex
@@ -57,7 +57,7 @@ defmodule Ask.MobileSurveyController do
           questionnaire = Enum.random(questionnaires)
           msg = questionnaire.settings["mobile_web_survey_is_over_message"] || "The survey is over"
           {end_step(msg), end_progress(), nil}
-        respondent.state in ["pending", "active", "stalled"] ->
+        respondent.state in ["pending", "active", "stalled", "rejected"] ->
           case Broker.sync_step(respondent, value) do
             {:reply, reply} ->
               {first_step(reply), progress(reply), reply.error_message}

--- a/web/controllers/questionnaire_controller.ex
+++ b/web/controllers/questionnaire_controller.ex
@@ -127,7 +127,7 @@ defmodule Ask.QuestionnaireController do
     questionnaire = load_questionnaire(project, id)
 
     audio_ids = collect_steps_audio_ids(questionnaire.steps, [])
-    audio_ids = collect_prompt_audio_ids(questionnaire.settings["quota_completed_message"], audio_ids)
+    audio_ids = collect_steps_audio_ids(questionnaire.quota_completed_steps, audio_ids)
     audio_ids = collect_prompt_audio_ids(questionnaire.settings["error_message"], audio_ids)
 
     audios =
@@ -156,7 +156,7 @@ defmodule Ask.QuestionnaireController do
       name: questionnaire.name,
       modes: questionnaire.modes,
       steps: questionnaire.steps,
-      quota_completed_message: questionnaire.settings["quota_completed_message"],
+      quota_completed_steps: questionnaire.quota_completed_steps,
       error_message: questionnaire.settings["error_message"],
       mobile_web_sms_message: questionnaire.settings["mobile_web_sms_message"],
       mobile_web_survey_is_over_message: questionnaire.settings["mobile_web_survey_is_over_message"],
@@ -205,8 +205,8 @@ defmodule Ask.QuestionnaireController do
       name: Map.get(manifest, "name"),
       modes: Map.get(manifest, "modes"),
       steps: Map.get(manifest, "steps"),
+      quota_completed_steps: Map.get(manifest, "quota_completed_steps"),
       settings: %{
-        quota_completed_message: Map.get(manifest, "quota_completed_message"),
         error_message: Map.get(manifest, "error_message"),
         mobile_web_sms_message: Map.get(manifest, "mobile_web_sms_message"),
         mobile_web_survey_is_over_message: Map.get(manifest, "mobile_web_survey_is_over_message")
@@ -232,6 +232,10 @@ defmodule Ask.QuestionnaireController do
         IO.inspect(json_errors)
         conn |> put_status(422) |> json(%{errors: json_errors}) |> halt
     end
+  end
+
+  defp collect_steps_audio_ids(nil, audio_ids) do
+    audio_ids
   end
 
   defp collect_steps_audio_ids(steps, audio_ids) do

--- a/web/models/translation.ex
+++ b/web/models/translation.ex
@@ -30,16 +30,16 @@ defmodule Ask.Translation do
 
     # First, collect questionnaire translations as
     # {mode, scope, source_lang, source_text, target_lang, target_text}
-    new_translations = questionnaire.steps
-    |> Enum.flat_map(&collect_step_translations(lang, &1))
-    |> collect_prompt_entry_translations("quota_completed", lang, questionnaire.settings["quota_completed_message"])
+    new_translations = []
+    |> collect_steps_translations(lang, questionnaire.steps)
+    |> collect_steps_translations(lang, questionnaire.quota_completed_steps)
     |> collect_prompt_entry_translations("error", lang, questionnaire.settings["error_message"])
 
     # Also collect all source texts, so later we can know which ones
     # don't have a translation yet (so we can still use them for autocomplete)
-    source_texts = questionnaire.steps
-    |> Enum.flat_map(&collect_step_source_texts(lang, &1))
-    |> collect_prompt_entry_source_texts("quota_completed", lang, questionnaire.settings["quota_completed_message"])
+    source_texts = []
+    |> collect_steps_source_texts(lang, questionnaire.steps)
+    |> collect_steps_source_texts(lang, questionnaire.quota_completed_steps)
     |> collect_prompt_entry_source_texts("error", lang, questionnaire.settings["error_message"])
 
     # Only keep source texts that are not already in `new_translations`
@@ -137,8 +137,18 @@ defmodule Ask.Translation do
   # Translations #
   # ------------ #
 
-  defp collect_step_translations(lang, step) do
-    []
+  defp collect_steps_translations(translations, _lang, nil) do
+    translations
+  end
+
+  defp collect_steps_translations(translations, lang, steps) do
+    Enum.reduce steps, translations, fn step, translations ->
+      collect_step_translations(translations, lang, step)
+    end
+  end
+
+  defp collect_step_translations(translations, lang, step) do
+    translations
     |> collect_prompt_translations(lang, step)
     |> collect_choices_translations(lang, step)
   end
@@ -265,8 +275,18 @@ defmodule Ask.Translation do
   # Source texts #
   # ------------ #
 
-  defp collect_step_source_texts(lang, step) do
-    []
+  defp collect_steps_source_texts(source_texts, _lang, nil) do
+    source_texts
+  end
+
+  defp collect_steps_source_texts(source_texts, lang, steps) do
+    Enum.reduce steps, source_texts, fn step, source_texts ->
+      collect_step_source_texts(source_texts, lang, step)
+    end
+  end
+
+  defp collect_step_source_texts(source_texts, lang, step) do
+    source_texts
     |> collect_prompt_source_texts(lang, step)
     |> collect_choices_source_texts(lang, step)
   end

--- a/web/static/js/actions/questionnaire.js
+++ b/web/static/js/actions/questionnaire.js
@@ -8,6 +8,7 @@ export const CHANGE_NAME = 'QUESTIONNAIRE_CHANGE_NAME'
 export const TOGGLE_MODE = 'QUESTIONNAIRE_TOGGLE_MODE'
 export const ADD_STEP = 'QUESTIONNAIRE_ADD_STEP'
 export const DELETE_STEP = 'QUESTIONNAIRE_DELETE_STEP'
+export const ADD_QUOTA_COMPLETED_STEP = 'QUESTIONNAIRE_ADD_QUOTA_COMPLETED_STEP'
 export const MOVE_STEP = 'QUESTIONNAIRE_MOVE_STEP'
 export const MOVE_STEP_TO_TOP = 'QUESTIONNAIRE_MOVE_STEP_TO_TOP'
 export const CHANGE_STEP_TITLE = 'QUESTIONNAIRE_CHANGE_STEP_TITLE'
@@ -48,6 +49,7 @@ export const SET_PRIMARY_COLOR = 'QUESTIONNAIRE_SET_PRIMARY_COLOR'
 export const SET_SECONDARY_COLOR = 'QUESTIONNAIRE_SET_SECONDARY_COLOR'
 export const SET_DISPLAYED_TITLE = 'QUESTIONNAIRE_SET_DISPLAYED_TITLE'
 export const SET_SURVEY_ALREADY_TAKEN_MESSAGE = 'QUESTIONNAIRE_SET_SURVEY_ALREADY_TAKEN_MESSAGE'
+export const TOGGLE_QUOTA_COMPLETED_STEPS = 'QUESTIONNAIRE_TOGGLE_QUOTA_COMPLETED_STEPS'
 
 export const fetchQuestionnaire = (projectId, id) => (dispatch, getState) => {
   dispatch(fetch(projectId, id))
@@ -181,6 +183,20 @@ export const addStep = () => ({
   type: ADD_STEP
 })
 
+export const addStepWithCallback = () => (dispatch, getState) => {
+  dispatch(addStep())
+  const q = getState().questionnaire.data
+  return Promise.resolve(q.steps[q.steps.length - 1])
+}
+
+export const addQuotaCompletedStep = () => (dispatch, getState) => {
+  dispatch({
+    type: ADD_QUOTA_COMPLETED_STEP
+  })
+  const q = getState().questionnaire.data
+  return Promise.resolve(q.quotaCompletedSteps[q.quotaCompletedSteps.length - 1])
+}
+
 export const moveStep = (sourceStepId, targetStepId) => ({
   type: MOVE_STEP,
   sourceStepId,
@@ -200,6 +216,10 @@ export const changeName = (newName) => ({
 export const toggleMode = (mode) => ({
   type: TOGGLE_MODE,
   mode
+})
+
+export const toggleQuotaCompletedSteps = () => ({
+  type: TOGGLE_QUOTA_COMPLETED_STEPS
 })
 
 export const saving = () => ({

--- a/web/static/js/components/questionnaires/DraggableStep.jsx
+++ b/web/static/js/components/questionnaires/DraggableStep.jsx
@@ -13,6 +13,7 @@ type Props = {
   connectDropTarget: Function,
   children: any,
   questionnaireActions: any,
+  quotaCompletedSteps: boolean,
   readOnly: boolean
 };
 
@@ -95,7 +96,15 @@ const mapDispatchToProps = (dispatch) => ({
   questionnaireActions: bindActionCreators(questionnaireActions, dispatch)
 })
 
-const source = DragSource('STEPS', stepSource, collectSource)(DraggableStep)
-const target = DropTarget('STEPS', stepTarget, collectTarget)(source)
+const typeFromProps = (props) => {
+  if (props.quotaCompletedSteps) {
+    return 'QUOTA_COMPLETED_STEPS'
+  } else {
+    return 'STEPS'
+  }
+}
+
+const source = DragSource(typeFromProps, stepSource, collectSource)(DraggableStep)
+const target = DropTarget(typeFromProps, stepTarget, collectTarget)(source)
 
 export default connect(null, mapDispatchToProps)(target)

--- a/web/static/js/components/questionnaires/ExplanationStepEditor.jsx
+++ b/web/static/js/components/questionnaires/ExplanationStepEditor.jsx
@@ -21,6 +21,7 @@ type Props = {
   errorPath: string,
   errorsByPath: ErrorsByPath,
   readOnly: boolean,
+  quotaCompletedSteps: boolean,
   stepsAfter: Step[],
   stepsBefore: Step[]
 };
@@ -70,11 +71,11 @@ class ExplanationStepEditor extends Component {
   }
 
   render() {
-    const { step, stepIndex, onCollapse, stepsAfter, stepsBefore, onDelete, errorPath, errorsByPath, readOnly } = this.props
+    const { step, stepIndex, onCollapse, stepsAfter, stepsBefore, onDelete, errorPath, errorsByPath, readOnly, quotaCompletedSteps } = this.props
 
     return (
-      <DraggableStep step={step} readOnly={readOnly}>
-        <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle} icon={<StepTypeSelector stepType={step.type} stepId={step.id} readOnly={readOnly} />} >
+      <DraggableStep step={step} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps}>
+        <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle} icon={<StepTypeSelector stepType={step.type} stepId={step.id} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps} />} >
           <StepPrompts
             step={step}
             readOnly={readOnly}

--- a/web/static/js/components/questionnaires/FlagStepEditor.jsx
+++ b/web/static/js/components/questionnaires/FlagStepEditor.jsx
@@ -77,7 +77,7 @@ class FlagStepEditor extends Component {
     const { step, onCollapse, stepsAfter, stepsBefore, onDelete, readOnly } = this.props
 
     return (
-      <DraggableStep step={step} readOnly={readOnly}>
+      <DraggableStep step={step} readOnly={readOnly} quotaCompletedSteps={false}>
         <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle} icon={<StepTypeSelector stepType={step.type} stepId={step.id} readOnly={readOnly} />} >
           <li className='collection-item' key='dispositions'>
             <h5>Disposition</h5>

--- a/web/static/js/components/questionnaires/LanguageSelectionStepEditor.jsx
+++ b/web/static/js/components/questionnaires/LanguageSelectionStepEditor.jsx
@@ -60,7 +60,7 @@ class LanguageSelectionStepEditor extends Component {
     const { step, stepIndex, onCollapse, errorPath, errorsByPath, readOnly } = this.props
 
     return (
-      <DraggableStep step={step} readOnly={readOnly}>
+      <DraggableStep step={step} readOnly={readOnly} quotaCompletedSteps={false}>
         <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle} icon={<i className='material-icons left'>language</i>} >
           <StepPrompts
             step={step}

--- a/web/static/js/components/questionnaires/MultipleChoiceStepEditor.jsx
+++ b/web/static/js/components/questionnaires/MultipleChoiceStepEditor.jsx
@@ -21,6 +21,7 @@ type Props = {
   onCollapse: Function,
   questionnaire: Questionnaire,
   readOnly: boolean,
+  quotaCompletedSteps: boolean,
   errorPath: string,
   errorsByPath: ErrorsByPath,
   stepsAfter: Step[],
@@ -62,13 +63,13 @@ class MultipleChoiceStepEditor extends Component {
   }
 
   render() {
-    const { step, stepIndex, onCollapse, questionnaire, readOnly, errorPath, errorsByPath, stepsAfter, stepsBefore, onDelete } = this.props
+    const { step, stepIndex, onCollapse, questionnaire, readOnly, quotaCompletedSteps, errorPath, errorsByPath, stepsAfter, stepsBefore, onDelete } = this.props
 
     return (
-      <DraggableStep step={step} readOnly={readOnly}>
+      <DraggableStep step={step} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps}>
         <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle}
           icon={
-            <StepTypeSelector stepType={step.type} stepId={step.id} readOnly={readOnly} />
+            <StepTypeSelector stepType={step.type} stepId={step.id} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps} />
           } >
           <StepPrompts
             step={step}

--- a/web/static/js/components/questionnaires/NumericStepEditor.jsx
+++ b/web/static/js/components/questionnaires/NumericStepEditor.jsx
@@ -21,6 +21,7 @@ type Props = {
   onCollapse: Function,
   questionnaire: Questionnaire,
   readOnly: boolean,
+  quotaCompletedSteps: boolean,
   errorPath: string,
   errorsByPath: ErrorsByPath,
   stepsAfter: Step[],
@@ -62,11 +63,11 @@ class NumericStepEditor extends Component {
   }
 
   render() {
-    const { step, stepIndex, onCollapse, questionnaire, readOnly, stepsAfter, stepsBefore, onDelete, errorPath, errorsByPath } = this.props
+    const { step, stepIndex, onCollapse, questionnaire, readOnly, quotaCompletedSteps, stepsAfter, stepsBefore, onDelete, errorPath, errorsByPath } = this.props
 
     return (
-      <DraggableStep step={step} readOnly={readOnly}>
-        <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle} icon={<StepTypeSelector stepType={step.type} readOnly={readOnly} stepId={step.id} />} >
+      <DraggableStep step={step} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps}>
+        <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle} icon={<StepTypeSelector stepType={step.type} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps} stepId={step.id} />} >
           <StepPrompts
             step={step}
             readOnly={readOnly}

--- a/web/static/js/components/questionnaires/PhoneCallSettings.jsx
+++ b/web/static/js/components/questionnaires/PhoneCallSettings.jsx
@@ -35,7 +35,6 @@ class PhoneCallSettings extends Component {
 
   stateFromProps(props) {
     return {
-      quotaCompletedMessage: props.quotaCompletedMessage,
       errorMessage: props.errorMessage,
       thankYouMessage: props.thankYouMessage
     }
@@ -130,9 +129,6 @@ class PhoneCallSettings extends Component {
                 </div>
               </div>
             </li>
-            <li className='collection-item quotaCompletedMessageAudio'>
-              {this.quotaCompletedMessageComponent()}
-            </li>
             <li className='collection-item errorMessageAudio'>
               {this.errorMessageComponent()}
             </li>
@@ -143,27 +139,6 @@ class PhoneCallSettings extends Component {
         </Card>
       </div>
     )
-  }
-
-  quotaCompletedMessageComponent() {
-    let ivrInputErrors = this.textErrors('quotaCompletedMessage')
-    let ivrAudioIdErrors = this.audioErrors('quotaCompletedMessage')
-    return <IvrPrompt id='settings_quota_completed_ivr'
-      label='Quota completed message'
-      inputErrors={ivrInputErrors}
-      audioIdErrors={ivrAudioIdErrors}
-      value={this.state.quotaCompletedMessage.text}
-      originalValue={this.state.quotaCompletedMessage.text}
-      onChange={e => this.textChange(e, 'quotaCompletedMessage')}
-      readOnly={this.props.readOnly}
-      onBlur={e => this.messageBlur(e, 'quotaCompletedMessage')}
-      changeIvrMode={(e, mode) => this.modeChange(e, mode, 'quotaCompletedMessage')}
-      ivrPrompt={this.state.quotaCompletedMessage}
-      customHandlerFileUpload={files => this.handleFileUpload(files, 'quotaCompletedMessage')}
-      autocomplete
-      autocompleteGetData={(value, callback) => this.autocompleteGetData(value, callback, 'quotaCompletedMessage')}
-      autocompleteOnSelect={(item) => this.autocompleteOnSelect(item, 'quotaCompletedMessage')}
-      />
   }
 
   errorMessageComponent() {
@@ -219,9 +194,7 @@ class PhoneCallSettings extends Component {
   }
 
   hasErrors() {
-    return !!this.textErrors('quotaCompletedMessage') ||
-      !!this.audioErrors('quotaCompletedMessage') ||
-      !!this.textErrors('errorMessage') ||
+    return !!this.textErrors('errorMessage') ||
       !!this.audioErrors('errorMessage')
   }
 
@@ -231,7 +204,7 @@ class PhoneCallSettings extends Component {
 
     const defaultLanguage = questionnaire.defaultLanguage
     const activeLanguage = questionnaire.activeLanguage
-    const scope = key == 'quotaCompletedMessage' ? 'quota_completed' : (key == 'errorMessage' ? 'error' : 'thank_you')
+    const scope = key == 'errorMessage' ? 'error' : 'thank_you'
 
     if (activeLanguage == defaultLanguage) {
       api.autocompletePrimaryLanguage(questionnaire.projectId, 'ivr', scope, defaultLanguage, value)
@@ -292,7 +265,6 @@ PhoneCallSettings.propTypes = {
   dispatch: PropTypes.any,
   questionnaire: PropTypes.object,
   errorsByPath: PropTypes.object,
-  quotaCompletedMessage: PropTypes.object,
   errorMessage: PropTypes.object,
   thankYouMessage: PropTypes.object,
   readOnly: PropTypes.bool
@@ -303,7 +275,6 @@ const mapStateToProps = (state, ownProps) => {
   return {
     questionnaire: quiz.data,
     errorsByPath: quiz.errorsByPath,
-    quotaCompletedMessage: quiz.data ? getPromptIvr(quiz.data.settings.quotaCompletedMessage, quiz.data.activeLanguage) : newIvrPrompt(),
     errorMessage: quiz.data ? getPromptIvr(quiz.data.settings.errorMessage, quiz.data.activeLanguage) : newIvrPrompt(),
     thankYouMessage: quiz.data ? getPromptIvr(quiz.data.settings.thankYouMessage, quiz.data.activeLanguage) : newIvrPrompt()
   }

--- a/web/static/js/components/questionnaires/QuestionnaireClosedStep.jsx
+++ b/web/static/js/components/questionnaires/QuestionnaireClosedStep.jsx
@@ -12,14 +12,15 @@ type Props = {
   errorPath: string,
   onClick: Function,
   hasErrors: boolean,
-  readOnly: boolean
+  readOnly: boolean,
+  quotaCompletedSteps: boolean
 };
 
 class QuestionnaireClosedStep extends Component {
   props: Props
 
   render() {
-    const { step, onClick, hasErrors, readOnly } = this.props
+    const { step, onClick, hasErrors, readOnly, quotaCompletedSteps } = this.props
 
     const stepIconClass = classNames({
       'material-icons left': true,
@@ -45,7 +46,7 @@ class QuestionnaireClosedStep extends Component {
     })()
 
     return (
-      <DraggableStep step={step} readOnly={readOnly}>
+      <DraggableStep step={step} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps}>
         <Card>
           <div className='card-content closed-step'>
             <div>

--- a/web/static/js/components/questionnaires/QuestionnaireEditor.jsx
+++ b/web/static/js/components/questionnaires/QuestionnaireEditor.jsx
@@ -20,48 +20,46 @@ import * as routes from '../../routes'
 import * as api from '../../api'
 
 type State = {
-  addingStep: boolean,
-  currentStep: ?Step,
-  currentStepIsNew: boolean,
   isNew: boolean
 };
 
 class QuestionnaireEditor extends Component {
   state: State
   preventSecondImportZipDialog: boolean
+  deleteStep: Function
 
   constructor(props) {
     super(props)
     this.preventSecondImportZipDialog = false
     const initialState = props.location.state
     const isNew = initialState && initialState.isNew
-    if (isNew) {
-      this.state = this.internalState(null, false, false, true)
-    } else {
-      this.state = this.internalState(null)
-    }
-  }
-
-  selectStep(stepId) {
-    this.setState(this.internalState(stepId))
-  }
-
-  deselectStep() {
-    this.setState(this.internalState(null))
+    this.state = {isNew}
+    this.deleteStep = this.deleteStep.bind(this)
   }
 
   toggleMode(event, mode) {
     this.props.questionnaireActions.toggleMode(mode)
   }
 
+  toggleQuotaCompletedSteps(e) {
+    this.props.questionnaireActions.toggleQuotaCompletedSteps()
+  }
+
   questionnaireAddStep(e) {
     e.preventDefault()
-    this.setState({
-      ...this.state,
-      addingStep: true
-    }, () => {
-      // Add the step then automatically expand it
-      this.props.questionnaireActions.addStep()
+
+    // Add the step then automatically expand it
+    this.props.questionnaireActions.addStepWithCallback().then(step => {
+      this.stepsComponent().selectStep(step.id, true)
+    })
+  }
+
+  questionnaireAddQuotaCompletedStep(e) {
+    e.preventDefault()
+
+    // Add the step then automatically expand it
+    this.props.questionnaireActions.addQuotaCompletedStep().then(step => {
+      this.quotaCompletedStepsComponent().selectStep(step.id, true)
     })
   }
 
@@ -69,45 +67,33 @@ class QuestionnaireEditor extends Component {
     this.props.userSettingsActions.hideOnboarding()
   }
 
-  deleteStep() {
-    const currentStepId = this.state.currentStep
-
-    this.setState({
-      currentStep: null,
-      addingStep: false
-    }, () => {
-      this.props.questionnaireActions.deleteStep(currentStepId)
-    })
+  deleteStep(stepId) {
+    this.props.questionnaireActions.deleteStep(stepId)
   }
 
-  internalState(currentStep, addingStep = false, currentStepIsNew = false, isNew = false) {
-    return {
-      currentStep,
-      addingStep,
-      currentStepIsNew,
-      isNew
-    }
+  stepsComponent() {
+    // Because QuestionnaireSteps is inside a DragDropContext
+    return this.refs.stepsComponent.child
+  }
+
+  quotaCompletedStepsComponent() {
+    // Because QuestionnaireSteps is inside a DragDropContext
+    return this.refs.quotaCompletedStepsComponent.child
   }
 
   componentWillReceiveProps(newProps) {
-    // This feels a bit hacky, but it let's us expand the step we just created.
-    // I couldn't find a better way. Ideally this should be a sort of "callback"
-    // to the addStep method, without involving additional component state handling
-    // or explicit management via Redux reducers.
-    const questionnaireData = newProps.questionnaire
+    const questionnaire = newProps.questionnaire
 
-    if (this.state.addingStep && questionnaireData && questionnaireData.steps != null && questionnaireData.steps.length > 0) {
-      const newStep = questionnaireData.steps[questionnaireData.steps.length - 1]
-      if (newStep != null) {
-        this.setState(this.internalState(newStep.id, false, true))
-      }
+    // If it's a new questionnaire, expand the first step
+    if (questionnaire && questionnaire.steps && questionnaire.steps.length > 0 && this.state.isNew) {
+      this.stepsComponent().selectStep(questionnaire.steps[0].id, true)
     }
-    // A questionnaireData.steps.length > 0 check is added because it's possible
-    // having a new questionnaire with 0 steps (deleting the first step and refreshing
-    // the page
-    if (questionnaireData && questionnaireData.steps && questionnaireData.steps.length > 0 && this.state.isNew) {
-      this.selectStep(questionnaireData.steps[0].id)
-    }
+
+    // Don't consider the questionnaire as new anymore, so the first step
+    // is not expanded again
+    this.setState({
+      isNew: false
+    })
   }
 
   componentWillMount() {
@@ -226,10 +212,7 @@ class QuestionnaireEditor extends Component {
     .then(response => {
       const questionnaire = response.entities.questionnaires[response.result]
       // Make sure to deselect any step before receiving the questionnaire
-      this.setState({
-        ...this.state,
-        currentStep: null
-      }, () => {
+      this.stepsComponent().deselectStep(() => {
         this.props.questionnaireActions.receive(questionnaire)
         importModal.close()
       })
@@ -264,11 +247,8 @@ class QuestionnaireEditor extends Component {
 
     // If only one language will be left, and the language select step
     // is selected, make sure to unselect it first
-    if (questionnaire.languages.length == 2 && questionnaire.steps[0].id == this.state.currentStep) {
-      this.setState({
-        ...this.state,
-        currentStep: null
-      })
+    if (questionnaire.languages.length == 2 && questionnaire.steps[0].id == this.stepsComponent().getCurrentStepId()) {
+      this.stepsComponent().deselectStep()
     }
 
     this.props.questionnaireActions.removeLanguage(lang)
@@ -285,6 +265,7 @@ class QuestionnaireEditor extends Component {
 
     const settings = userSettings.settings
     const skipOnboarding = settings.onboarding && settings.onboarding.questionnaire
+    const hasQuotaCompletedSteps = !!questionnaire.quotaCompletedSteps
 
     if (!readOnly) {
       csvButtons = <div>
@@ -380,14 +361,11 @@ class QuestionnaireEditor extends Component {
         {skipOnboarding
         ? <div className='col s12 m8 offset-m1'>
           <QuestionnaireSteps
+            ref='stepsComponent'
             steps={questionnaire.steps}
             errorPath='steps'
             errorsByPath={errorsByPath}
-            current={this.state.currentStep}
-            currentStepIsNew={this.state.currentStepIsNew}
-            onSelectStep={stepId => this.selectStep(stepId)}
-            onDeselectStep={() => this.deselectStep()}
-            onDeleteStep={() => this.deleteStep()}
+            onDeleteStep={this.deleteStep}
             readOnly={readOnly}
             />
           {readOnly ? null
@@ -396,6 +374,36 @@ class QuestionnaireEditor extends Component {
               <a href='#!' className='btn-flat blue-text no-padd' onClick={e => this.questionnaireAddStep(e)}>Add Step</a>
             </div>
           </div>
+          }
+          <div className='row'>
+            <div className='col s12'>
+              <div className='switch'>
+                <label>
+                  <input type='checkbox' checked={hasQuotaCompletedSteps} onChange={e => this.toggleQuotaCompletedSteps(e)} disabled={readOnly} />
+                  <span className='lever' />
+                </label>
+                Quota completed steps
+              </div>
+            </div>
+          </div>
+          {hasQuotaCompletedSteps
+          ? <QuestionnaireSteps
+            ref='quotaCompletedStepsComponent'
+            quotaCompletedSteps
+            steps={questionnaire.quotaCompletedSteps}
+            errorPath='quotaCompletedSteps'
+            errorsByPath={errorsByPath}
+            onDeleteStep={this.deleteStep}
+            readOnly={readOnly}
+            />
+          : null}
+          {!readOnly && hasQuotaCompletedSteps
+          ? <div className='row'>
+            <div className='col s12'>
+              <a href='#!' className='btn-flat blue-text no-padd' onClick={e => this.questionnaireAddQuotaCompletedStep(e)}>Add Quota Completed Step</a>
+            </div>
+          </div>
+          : null
           }
           { sms
           ? <SmsSettings readOnly={readOnly} />

--- a/web/static/js/components/questionnaires/QuestionnaireSteps.jsx
+++ b/web/static/js/components/questionnaires/QuestionnaireSteps.jsx
@@ -6,28 +6,75 @@ import { DragDropContext } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
 import DraggableStep from './DraggableStep'
 
+type State = {
+  currentStepId: ?string,
+  currentStepIsNew: boolean
+};
+
 type Props = {
   steps: Step[],
   errorPath: string,
   errorsByPath: ErrorsByPath,
-  current: ?string,
-  currentStepIsNew: boolean,
   readOnly: boolean,
   onSelectStep: Function,
   onDeselectStep: Function,
   onDeleteStep: Function,
-  readOnly: boolean
+  readOnly: boolean,
+  quotaCompletedSteps?: boolean
 };
 
 class QuestionnaireSteps extends Component {
   props: Props
+  state: State
+  selectStep: Function
+  deselectStep: Function
+  deleteStep: Function
+
+  constructor(props) {
+    super(props)
+    this.selectStep = this.selectStep.bind(this)
+    this.deselectStep = this.deselectStep.bind(this)
+    this.deleteStep = this.deleteStep.bind(this)
+
+    this.state = {
+      currentStepId: null,
+      currentStepIsNew: false
+    }
+  }
+
+  getCurrentStepId() {
+    return this.state.currentStepId
+  }
+
+  selectStep(stepId, isNew = false) {
+    this.setState({
+      currentStepId: stepId,
+      currentStepIsNew: isNew
+    })
+  }
+
+  deselectStep(callback) {
+    this.setState({
+      currentStepId: null,
+      currentStepIsNew: false
+    }, callback || (() => {}))
+  }
+
+  deleteStep() {
+    const { onDeleteStep } = this.props
+
+    const currentStepId = this.state.currentStepId
+    this.setState({currentStepId: null}, () => {
+      onDeleteStep(currentStepId)
+    })
+  }
 
   dummyDropTarget() {
-    const { steps, readOnly } = this.props
+    const { steps, readOnly, quotaCompletedSteps } = this.props
 
     if (steps && steps.length > 0 && steps[0].type != 'language-selection') {
       return (
-        <DraggableStep step={null} readOnly={readOnly}>
+        <DraggableStep step={null} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps}>
           <div style={{borderBottom: 'solid transparent'}} />
         </DraggableStep>
       )
@@ -37,11 +84,13 @@ class QuestionnaireSteps extends Component {
   }
 
   questionnaireSteps() {
-    const { steps, errorPath, errorsByPath, current, currentStepIsNew, onSelectStep, onDeselectStep, onDeleteStep, readOnly } = this.props
+    const { steps, errorPath, errorsByPath, readOnly, quotaCompletedSteps } = this.props
+    const current = this.state.currentStepId
+    const currentStepIsNew = this.state.currentStepIsNew
 
     if (current == null) {
       // All collapsed
-      return <StepsList steps={steps} errorPath={errorPath} onClick={stepId => onSelectStep(stepId)} readOnly={readOnly} />
+      return <StepsList steps={steps} errorPath={errorPath} onClick={this.selectStep} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps} />
     } else {
       const itemIndex = steps.findIndex(step => step.id == current)
 
@@ -52,19 +101,20 @@ class QuestionnaireSteps extends Component {
 
       return (
         <div>
-          <StepsList steps={stepsBefore} errorPath={errorPath} onClick={stepId => onSelectStep(stepId)} readOnly={readOnly} />
+          <StepsList steps={stepsBefore} errorPath={errorPath} onClick={this.selectStep} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps} />
           <StepEditor
             step={currentStep}
             stepIndex={itemIndex}
             errorPath={`${errorPath}[${itemIndex}]`}
             errorsByPath={errorsByPath}
             readOnly={readOnly}
+            quotaCompletedSteps={!!quotaCompletedSteps}
             isNew={currentStepIsNew}
-            onCollapse={() => onDeselectStep()}
-            onDelete={() => onDeleteStep()}
+            onCollapse={this.deselectStep}
+            onDelete={this.deleteStep}
             stepsAfter={stepsAfter}
             stepsBefore={stepsBefore} />
-          <StepsList steps={stepsAfter} onClick={stepId => onSelectStep(stepId)} readOnly={readOnly} />
+          <StepsList steps={stepsAfter} onClick={this.selectStep} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps} />
         </div>
       )
     }

--- a/web/static/js/components/questionnaires/SmsSettings.jsx
+++ b/web/static/js/components/questionnaires/SmsSettings.jsx
@@ -34,7 +34,6 @@ class SmsSettings extends Component {
 
   stateFromProps(props) {
     return {
-      quotaCompletedMessage: props.quotaCompletedMessage,
       errorMessage: props.errorMessage,
       thankYouMessage: props.thankYouMessage
     }
@@ -94,9 +93,6 @@ class SmsSettings extends Component {
               </div>
             </li>
             <li className='collection-item'>
-              {this.quotaCompletedMessageComponent()}
-            </li>
-            <li className='collection-item'>
               {this.errorMessageComponent()}
             </li>
             <li className='collection-item'>
@@ -106,21 +102,6 @@ class SmsSettings extends Component {
         </Card>
       </div>
     )
-  }
-
-  quotaCompletedMessageComponent() {
-    return <SmsPrompt id='sms_settings_quota_completed'
-      label='Quota completed message'
-      inputErrors={this.messageErrors('quotaCompletedMessage')}
-      value={this.state.quotaCompletedMessage}
-      originalValue={this.state.quotaCompletedMessage}
-      readOnly={this.props.readOnly}
-      onChange={text => this.messageChange(text, 'quotaCompletedMessage')}
-      onBlur={text => this.messageBlur(text, 'quotaCompletedMessage')}
-      autocomplete
-      autocompleteGetData={(value, callback) => this.autocompleteGetData(value, callback, 'quotaCompletedMessage')}
-      autocompleteOnSelect={(item) => this.autocompleteOnSelect(item, 'quotaCompletedMessage')}
-      />
   }
 
   errorMessageComponent() {
@@ -159,7 +140,7 @@ class SmsSettings extends Component {
   }
 
   hasErrors() {
-    return !!this.messageErrors('quotaCompletedMessage') || !!this.messageErrors('errorMessage')
+    return !!this.messageErrors('errorMessage')
   }
 
   autocompleteGetData(value, callback, key) {
@@ -168,7 +149,7 @@ class SmsSettings extends Component {
 
     const defaultLanguage = questionnaire.defaultLanguage
     const activeLanguage = questionnaire.activeLanguage
-    const scope = key == 'quotaCompletedMessage' ? 'quota_completed' : (key == 'errorMessage' ? 'error' : 'thank_you')
+    const scope = key == 'errorMessage' ? 'error' : 'thank_you'
 
     if (activeLanguage == defaultLanguage) {
       api.autocompletePrimaryLanguage(questionnaire.projectId, 'sms', scope, defaultLanguage, value)
@@ -225,7 +206,6 @@ SmsSettings.propTypes = {
   dispatch: PropTypes.any,
   questionnaire: PropTypes.object,
   errorsByPath: PropTypes.object,
-  quotaCompletedMessage: PropTypes.string,
   errorMessage: PropTypes.string,
   thankYouMessage: PropTypes.string,
   readOnly: PropTypes.bool
@@ -236,7 +216,6 @@ const mapStateToProps = (state, ownProps) => {
   return {
     questionnaire: quiz.data,
     errorsByPath: quiz.errorsByPath,
-    quotaCompletedMessage: quiz.data ? getPromptSms(quiz.data.settings.quotaCompletedMessage, quiz.data.activeLanguage) : '',
     errorMessage: quiz.data ? getPromptSms(quiz.data.settings.errorMessage, quiz.data.activeLanguage) : '',
     thankYouMessage: quiz.data ? getPromptSms(quiz.data.settings.thankYouMessage, quiz.data.activeLanguage) : ''
 

--- a/web/static/js/components/questionnaires/StepEditor.jsx
+++ b/web/static/js/components/questionnaires/StepEditor.jsx
@@ -16,6 +16,7 @@ type Props = {
   errorsByPath: ErrorsByPath,
   questionnaireActions: any,
   readOnly: boolean,
+  quotaCompletedSteps: boolean,
   onDelete: Function,
   onCollapse: Function,
   stepsAfter: Step[],

--- a/web/static/js/components/questionnaires/StepTypeSelector.jsx
+++ b/web/static/js/components/questionnaires/StepTypeSelector.jsx
@@ -8,6 +8,7 @@ import * as questionnaireActions from '../../actions/questionnaire'
 type Props = {
   stepType: string,
   readOnly: boolean,
+  quotaCompletedSteps?: boolean,
   stepId: any,
   questionnaireActions: any
 };
@@ -20,7 +21,7 @@ class StepTypeSelector extends Component {
   }
 
   render() {
-    const { stepType, readOnly } = this.props
+    const { stepType, readOnly, quotaCompletedSteps } = this.props
 
     const label = (() => {
       switch (stepType) {
@@ -60,13 +61,15 @@ class StepTypeSelector extends Component {
             {stepType == 'explanation' ? <i className='material-icons right'>done</i> : ''}
           </a>
         </DropdownItem>
-        <DropdownItem>
+        { quotaCompletedSteps
+        ? null
+        : <DropdownItem>
           <a onClick={e => this.changeStepType('flag')}>
             <i className='material-icons left sharp'>flag</i>
             Flag
             {stepType == 'flag' ? <i className='material-icons right'>done</i> : ''}
           </a>
-        </DropdownItem>
+        </DropdownItem> }
       </Dropdown>
     </div>
     )

--- a/web/static/js/components/questionnaires/StepsList.jsx
+++ b/web/static/js/components/questionnaires/StepsList.jsx
@@ -3,7 +3,7 @@ import QuestionnaireClosedStep from './QuestionnaireClosedStep'
 
 class StepsList extends Component {
   render() {
-    const { steps, errorPath, onClick, readOnly } = this.props
+    const { steps, errorPath, onClick, readOnly, quotaCompletedSteps } = this.props
     if (steps.length != 0) {
       return (
         <ul className='collapsible'>
@@ -15,6 +15,7 @@ class StepsList extends Component {
                 errorPath={`${errorPath}[${index}]`}
                 onClick={stepId => onClick(stepId)}
                 readOnly={readOnly}
+                quotaCompletedSteps={quotaCompletedSteps}
               />
             </li>
           ))}
@@ -30,7 +31,8 @@ StepsList.propTypes = {
   steps: PropTypes.array,
   errorPath: PropTypes.string,
   onClick: PropTypes.func,
-  readOnly: PropTypes.bool
+  readOnly: PropTypes.bool,
+  quotaCompletedSteps: PropTypes.bool
 }
 
 export default StepsList

--- a/web/static/js/components/questionnaires/WebSettings.jsx
+++ b/web/static/js/components/questionnaires/WebSettings.jsx
@@ -34,7 +34,6 @@ class WebSettings extends Component {
 
   stateFromProps(props) {
     return {
-      quotaCompletedMessage: props.quotaCompletedMessage,
       errorMessage: props.errorMessage,
       thankYouMessage: props.thankYouMessage,
       title: props.title,
@@ -131,9 +130,6 @@ class WebSettings extends Component {
               <h5>
                 Messages
               </h5>
-              {this.quotaCompletedMessageComponent()}
-            </li>
-            <li className='collection-item'>
               {this.errorMessageComponent()}
             </li>
             <li className='collection-item'>
@@ -155,18 +151,6 @@ class WebSettings extends Component {
         </Card>
       </div>
     )
-  }
-
-  quotaCompletedMessageComponent() {
-    return <MobileWebPrompt id='web_settings_quota_completed'
-      label='Quota completed message'
-      inputErrors={this.messageErrors('quotaCompletedMessage')}
-      value={this.state.quotaCompletedMessage}
-      originalValue={this.state.quotaCompletedMessage}
-      onChange={text => this.messageChange(text, 'quotaCompletedMessage')}
-      onBlur={text => this.messageBlur(text, 'quotaCompletedMessage')}
-      readOnly={this.props.readOnly}
-      />
   }
 
   errorMessageComponent() {
@@ -319,8 +303,7 @@ class WebSettings extends Component {
   }
 
   hasErrors() {
-    return !!this.messageErrors('quotaCompletedMessage') ||
-      !!this.messageErrors('errorMessage') ||
+    return !!this.messageErrors('errorMessage') ||
       !!this.messageErrors('thankYouMessage') ||
       !!this.titleErrors() ||
       !!this.smsMessageErrors() ||
@@ -348,7 +331,6 @@ WebSettings.propTypes = {
   dispatch: PropTypes.any,
   questionnaire: PropTypes.object,
   errorsByPath: PropTypes.object,
-  quotaCompletedMessage: PropTypes.string,
   errorMessage: PropTypes.string,
   thankYouMessage: PropTypes.string,
   title: PropTypes.string,
@@ -364,7 +346,6 @@ const mapStateToProps = (state, ownProps) => {
   return {
     questionnaire: quiz.data,
     errorsByPath: quiz.errorsByPath,
-    quotaCompletedMessage: quiz.data ? getPromptMobileWeb(quiz.data.settings.quotaCompletedMessage, quiz.data.activeLanguage) : '',
     errorMessage: quiz.data ? getPromptMobileWeb(quiz.data.settings.errorMessage, quiz.data.activeLanguage) : '',
     thankYouMessage: quiz.data ? getPromptMobileWeb(quiz.data.settings.thankYouMessage, quiz.data.activeLanguage) : '',
     title: quiz.data ? (quiz.data.settings.title || {})[quiz.data.activeLanguage] || '' : '',

--- a/web/static/js/decls/questionnaire.js
+++ b/web/static/js/decls/questionnaire.js
@@ -2,6 +2,7 @@
 export type Questionnaire = {
   name: string,
   steps: Step[],
+  quotaCompletedSteps: ?(Step[]),
   modes: string[],
   languages: string[],
   defaultLanguage: string,
@@ -12,13 +13,12 @@ export type Questionnaire = {
 };
 
 export type Settings = {
-  quotaCompletedMessage?: Prompt,
-  errorMessage?: Prompt,
-  mobileWebSmsMessage?: ?string,
-  mobileWebSurveyIsOverMessage?: ?string,
+  errorMessage: Prompt,
+  mobileWebSmsMessage: ?string,
+  mobileWebSurveyIsOverMessage: ?string,
   mobileWebColorStyle?: ColorStylePrompt,
-  title?: {[lang: string]: string},
-  surveyAlreadyTakenMessage?: {[lang: string]: string},
+  title: {[lang: string]: string},
+  surveyAlreadyTakenMessage: {[lang: string]: string},
   thankYouMessage?: Prompt,
 };
 

--- a/web/static/js/reducers/questionnaire.js
+++ b/web/static/js/reducers/questionnaire.js
@@ -18,6 +18,7 @@ const dataReducer = (state: Questionnaire, action): Questionnaire => {
   switch (action.type) {
     case actions.CHANGE_NAME: return changeName(state, action)
     case actions.TOGGLE_MODE: return toggleMode(state, action)
+    case actions.TOGGLE_QUOTA_COMPLETED_STEPS: return toggleQuotaCompletedSteps(state, action)
     case actions.ADD_LANGUAGE: return addLanguage(state, action)
     case actions.REMOVE_LANGUAGE: return removeLanguage(state, action)
     case actions.SET_DEFAULT_LANGUAGE: return setDefaultLanguage(state, action)
@@ -35,7 +36,31 @@ const dataReducer = (state: Questionnaire, action): Questionnaire => {
     case actions.SET_SECONDARY_COLOR: return setSecondaryColor(state, action)
     case actions.SET_DISPLAYED_TITLE: return setDisplayedTitle(state, action)
     case actions.SET_SURVEY_ALREADY_TAKEN_MESSAGE: return setSurveyAlreadyTakenMessage(state, action)
-    default: return steps(state, action)
+    case actions.ADD_STEP: return addStep(state, action)
+    case actions.ADD_QUOTA_COMPLETED_STEP: return addQuotaCompletedStep(state, action)
+    case actions.MOVE_STEP: return moveStep(state, action)
+    case actions.MOVE_STEP_TO_TOP: return moveStepToTop(state, action)
+    case actions.CHANGE_STEP_TITLE: return changeStepTitle(state, action)
+    case actions.CHANGE_STEP_TYPE: return changeStepType(state, action)
+    case actions.CHANGE_STEP_PROMPT_SMS: return changeStepSmsPrompt(state, action)
+    case actions.CHANGE_STEP_PROMPT_IVR: return changeStepIvrPrompt(state, action)
+    case actions.CHANGE_STEP_PROMPT_MOBILE_WEB: return changeStepMobileWebPrompt(state, action)
+    case actions.CHANGE_STEP_AUDIO_ID_IVR: return changeStepIvrAudioId(state, action)
+    case actions.CHANGE_STEP_STORE: return changeStepStore(state, action)
+    case actions.AUTOCOMPLETE_STEP_PROMPT_SMS: return autocompleteStepSmsPrompt(state, action)
+    case actions.AUTOCOMPLETE_STEP_PROMPT_IVR: return autocompleteStepIvrPrompt(state, action)
+    case actions.DELETE_STEP: return deleteStep(state, action)
+    case actions.ADD_CHOICE: return addChoice(state, action)
+    case actions.DELETE_CHOICE: return deleteChoice(state, action)
+    case actions.CHANGE_CHOICE: return changeChoice(state, action)
+    case actions.AUTOCOMPLETE_CHOICE_SMS_VALUES: return autocompleteChoiceSmsValues(state, action)
+    case actions.CHANGE_NUMERIC_RANGES: return changeNumericRanges(state, action)
+    case actions.CHANGE_RANGE_SKIP_LOGIC: return changeRangeSkipLogic(state, action)
+    case actions.CHANGE_EXPLANATION_STEP_SKIP_LOGIC: return changeExplanationStepSkipLogic(state, action)
+    case actions.CHANGE_DISPOSITION: return changeDisposition(state, action)
+    case actions.TOGGLE_ACCEPT_REFUSALS: return toggleAcceptsRefusals(state, action)
+    case actions.CHANGE_REFUSAL: return changeRefusal(state, action)
+    default: return state
   }
 }
 
@@ -72,60 +97,6 @@ const dirtyPredicate = (action, oldData, newData) => {
 
 export default validateReducer(fetchReducer(actions, dataReducer, null, dirtyPredicate))
 
-const steps = (state, action) => {
-  // Up to now we've been assuming that all content was under corresponding 'en' keys,
-  // now that languages can be added and removed and default language can be
-  // set to whatever the user wants, that assumption is not safe anymore.
-  // Moreover, most of the actions that the stepsReducer needs to handle will need
-  // questionnaire level knowledge, namely the set of all questionnaire languages
-  // and the questionnaire's default language.
-  // Given we are on a tight schedule, I chose to pass the questionnaire down
-  // to the stepsReducer in a separate variable so there are no conflicts.
-  // That's the `state` argument added to the stepsReducer call.
-  // Multilanguage has impacted the application much more thoroughly than we had
-  // anticipated, this is a compromise solution that should be revised.
-  const newSteps = state.steps == null ? [] : stepsReducer(state.steps, action, state)
-
-  if (newSteps !== state.steps) {
-    return {
-      ...state,
-      steps: newSteps
-    }
-  } else {
-    return state
-  }
-}
-
-const stepsReducer = (state: Step[], action, quiz: Questionnaire) => {
-  switch (action.type) {
-    case actions.ADD_STEP: return addStep(state, action)
-    case actions.MOVE_STEP: return moveStep(state, action)
-    case actions.MOVE_STEP_TO_TOP: return moveStepToTop(state, action)
-    case actions.CHANGE_STEP_TITLE: return changeStepTitle(state, action)
-    case actions.CHANGE_STEP_TYPE: return changeStepType(state, action)
-    case actions.CHANGE_STEP_PROMPT_SMS: return changeStepSmsPrompt(state, action, quiz)
-    case actions.CHANGE_STEP_PROMPT_IVR: return changeStepIvrPrompt(state, action, quiz)
-    case actions.CHANGE_STEP_PROMPT_MOBILE_WEB: return changeStepMobileWebPrompt(state, action, quiz)
-    case actions.CHANGE_STEP_AUDIO_ID_IVR: return changeStepIvrAudioId(state, action, quiz)
-    case actions.CHANGE_STEP_STORE: return changeStepStore(state, action)
-    case actions.AUTOCOMPLETE_STEP_PROMPT_SMS: return autocompleteStepSmsPrompt(state, action, quiz)
-    case actions.AUTOCOMPLETE_STEP_PROMPT_IVR: return autocompleteStepIvrPrompt(state, action, quiz)
-    case actions.DELETE_STEP: return deleteStep(state, action)
-    case actions.ADD_CHOICE: return addChoice(state, action)
-    case actions.DELETE_CHOICE: return deleteChoice(state, action)
-    case actions.CHANGE_CHOICE: return changeChoice(state, action, quiz)
-    case actions.AUTOCOMPLETE_CHOICE_SMS_VALUES: return autocompleteChoiceSmsValues(state, action, quiz)
-    case actions.CHANGE_NUMERIC_RANGES: return changeNumericRanges(state, action)
-    case actions.CHANGE_RANGE_SKIP_LOGIC: return changeRangeSkipLogic(state, action)
-    case actions.CHANGE_EXPLANATION_STEP_SKIP_LOGIC: return changeExplanationStepSkipLogic(state, action)
-    case actions.CHANGE_DISPOSITION: return changeDisposition(state, action)
-    case actions.TOGGLE_ACCEPT_REFUSALS: return toggleAcceptsRefusals(state, action)
-    case actions.CHANGE_REFUSAL: return changeRefusal(state, action, quiz)
-  }
-
-  return state
-}
-
 const addChoice = (state, action) => {
   return changeStep(state, action.stepId, step => ({
     ...step,
@@ -155,14 +126,14 @@ const deleteChoice = (state, action) => {
   }))
 }
 
-const changeChoice = (state, action, quiz: Questionnaire) => {
+const changeChoice = (state, action) => {
   let response = action.choiceChange.response.trim()
   let smsValues = action.choiceChange.smsValues.trim()
   let ivrValues = action.choiceChange.ivrValues.trim()
   let mobilewebValues = action.choiceChange.mobilewebValues.trim()
 
   if (action.choiceChange.autoComplete && smsValues == '' && ivrValues == '') {
-    [smsValues, ivrValues] = autoComplete(state, response, quiz)
+    [smsValues, ivrValues] = autoComplete(state, response)
   }
 
   return changeStep(state, action.stepId, (step) => {
@@ -181,11 +152,11 @@ const changeChoice = (state, action, quiz: Questionnaire) => {
             ivr: splitValues(ivrValues),
             sms: {
               ...choice.responses.sms,
-              [quiz.activeLanguage]: splitValues(smsValues)
+              [state.activeLanguage]: splitValues(smsValues)
             },
             mobileweb: {
               ...choice.responses.mobileweb,
-              [quiz.activeLanguage]: mobilewebValues
+              [state.activeLanguage]: mobilewebValues
             }
           },
           skipLogic: action.choiceChange.skipLogic
@@ -196,7 +167,7 @@ const changeChoice = (state, action, quiz: Questionnaire) => {
   })
 }
 
-const autocompleteChoiceSmsValues = (state, action, quiz: Questionnaire) => {
+const autocompleteChoiceSmsValues = (state, action) => {
   return changeStep(state, action.stepId, (step) => {
     const previousChoices = step.choices.slice(0, action.index)
     const choice = step.choices[action.index]
@@ -211,7 +182,7 @@ const autocompleteChoiceSmsValues = (state, action, quiz: Questionnaire) => {
     newResponses.sms = newSms
 
     // First change default language
-    newSms[quiz.defaultLanguage] = splitValues(action.item.text)
+    newSms[state.defaultLanguage] = splitValues(action.item.text)
 
     // Then change other languages
     for (let translation of action.item.translations) {
@@ -234,20 +205,21 @@ const autocompleteChoiceSmsValues = (state, action, quiz: Questionnaire) => {
   })
 }
 
-const autoComplete = (state, value, quiz: Questionnaire) => {
+const autoComplete = (state, value) => {
   let setted = false
 
   let smsValues = ''
   let ivrValues = ''
 
-  state.forEach((step) => {
+  const steps = state.steps
+  steps.forEach((step) => {
     if ((step.type === 'multiple-choice') && !setted) {
       step.choices.forEach((choice) => {
         if (choice.value == value && !setted) {
           setted = true
 
-          if (choice.responses.sms && choice.responses.sms[quiz.activeLanguage]) {
-            smsValues = choice.responses.sms[quiz.activeLanguage].join(',')
+          if (choice.responses.sms && choice.responses.sms[state.activeLanguage]) {
+            smsValues = choice.responses.sms[state.activeLanguage].join(',')
           }
 
           if (choice.responses.ivr) {
@@ -265,13 +237,34 @@ const splitValues = (values) => {
 }
 
 const deleteStep = (state, action) => {
-  return filter(state, s => s.id != action.stepId)
+  const stepId = action.stepId
+
+  // First see if the step is in 'steps'
+  let steps = state.steps
+  let stepIndex = findIndex(steps, s => s.id === stepId)
+  if (stepIndex != -1) {
+    return {
+      ...state,
+      steps: filter(steps, s => s.id != stepId)
+    }
+  }
+
+  // Otherwise it means it's in 'quotaCompletedSteps'
+  steps = state.quotaCompletedSteps
+  if (steps) {
+    stepIndex = findIndex(steps, s => s.id === stepId)
+    if (stepIndex != -1) {
+      return {
+        ...state,
+        quotaCompletedSteps: filter(steps, s => s.id != stepId)
+      }
+    }
+  }
+
+  throw new Error(`Bug: couldn't find step ${stepId}`)
 }
 
 const moveStep = (state, action) => {
-  const stepToMove = state[findIndex(state, s => s.id === action.sourceStepId)]
-  const stepAbove = state[findIndex(state, s => s.id === action.targetStepId)]
-
   const move = (accum, step) => {
     if (step.id != stepToMove.id) {
       accum.push(step)
@@ -284,22 +277,97 @@ const moveStep = (state, action) => {
     return accum
   }
 
-  return reduce(state, move, [])
+  // First try with 'steps'
+  let steps = state.steps
+  let stepToMove = steps[findIndex(steps, s => s.id === action.sourceStepId)]
+  let stepAbove = steps[findIndex(steps, s => s.id === action.targetStepId)]
+
+  if (stepToMove && stepAbove) {
+    return {
+      ...state,
+      steps: reduce(steps, move, [])
+    }
+  }
+
+  // Otherwise try with 'quotaCompletedSteps'
+  steps = state.quotaCompletedSteps
+  if (steps) {
+    stepToMove = steps[findIndex(steps, s => s.id === action.sourceStepId)]
+    stepAbove = steps[findIndex(steps, s => s.id === action.targetStepId)]
+
+    if (stepToMove && stepAbove) {
+      return {
+        ...state,
+        quotaCompletedSteps: reduce(steps, move, [])
+      }
+    }
+  }
+
+  // If none of the above worked, it probably means one step was dragged
+  // from 'steps' to 'quotaCompletedSteps' or the other way around,
+  // and we don't care about that case
+  return state
 }
 
 const moveStepToTop = (state, action) => {
-  const stepToMove = state[findIndex(state, s => s.id === action.stepId)]
-  return concat([stepToMove], reject(state, s => s.id === action.stepId))
+  // First try with 'steps'
+  let steps = state.steps
+  let stepToMove = steps[findIndex(steps, s => s.id === action.stepId)]
+  if (stepToMove) {
+    return {
+      ...state,
+      steps: concat([stepToMove], reject(steps, s => s.id === action.stepId))
+    }
+  }
+
+  // Otherwise try with 'quotaCompletedSteps'
+  steps = state.quotaCompletedSteps
+  if (steps) {
+    stepToMove = steps[findIndex(steps, s => s.id === action.stepId)]
+    if (stepToMove) {
+      return {
+        ...state,
+        quotaCompletedSteps: concat([stepToMove], reject(steps, s => s.id === action.stepId))
+      }
+    }
+  }
+
+  throw new Error(`Couldn't move step ${action.stepId} to the top`)
 }
 
 function changeStep<T: Step>(state, stepId, func: (step: Object) => T) {
-  const stepIndex = findIndex(state, s => s.id == stepId)
+  // First try to find the step in 'steps'
+  let steps = state.steps
+  let stepIndex = findIndex(steps, s => s.id == stepId)
 
-  return [
-    ...state.slice(0, stepIndex),
-    func(state[stepIndex]),
-    ...state.slice(stepIndex + 1)
-  ]
+  if (stepIndex != -1) {
+    return {
+      ...state,
+      steps: [
+        ...steps.slice(0, stepIndex),
+        func(steps[stepIndex]),
+        ...steps.slice(stepIndex + 1)
+      ]
+    }
+  }
+
+  // If we couldn't find it there, it must be in 'quotaCompletedSteps'
+  steps = state.quotaCompletedSteps
+  if (steps) {
+    stepIndex = findIndex(steps, s => s.id == stepId)
+    if (stepIndex != -1) {
+      return {
+        ...state,
+        quotaCompletedSteps: [
+          ...steps.slice(0, stepIndex),
+          func(steps[stepIndex]),
+          ...steps.slice(stepIndex + 1)
+        ]
+      }
+    }
+  }
+
+  throw new Error(`Bug: couldn't find step ${stepId}`)
 }
 
 type ActionChangeStepSmsPrompt = {
@@ -307,28 +375,28 @@ type ActionChangeStepSmsPrompt = {
   newPrompt: string
 };
 
-const changeStepSmsPrompt = (state, action: ActionChangeStepSmsPrompt, quiz: Questionnaire): Step[] => {
+const changeStepSmsPrompt = (state, action: ActionChangeStepSmsPrompt) => {
   return changeStep(state, action.stepId, step => {
-    return setStepPrompt(step, quiz.activeLanguage, prompt => ({
+    return setStepPrompt(step, state.activeLanguage, prompt => ({
       ...prompt,
       sms: action.newPrompt.trim()
     }))
   })
 }
 
-const changeStepMobileWebPrompt = (state, action: ActionChangeStepSmsPrompt, quiz: Questionnaire): Step[] => {
+const changeStepMobileWebPrompt = (state, action: ActionChangeStepSmsPrompt) => {
   return changeStep(state, action.stepId, step => {
-    return setStepPrompt(step, quiz.activeLanguage, prompt => ({
+    return setStepPrompt(step, state.activeLanguage, prompt => ({
       ...prompt,
       mobileweb: action.newPrompt.trim()
     }))
   })
 }
 
-const autocompleteStepSmsPrompt = (state, action, quiz: Questionnaire): Step[] => {
+const autocompleteStepSmsPrompt = (state, action) => {
   return changeStep(state, action.stepId, step => {
     // First change default language
-    step = setStepPrompt(step, quiz.defaultLanguage, prompt => ({
+    step = setStepPrompt(step, state.defaultLanguage, prompt => ({
       ...prompt,
       sms: action.item.text.trim()
     }))
@@ -353,10 +421,10 @@ const autocompleteStepSmsPrompt = (state, action, quiz: Questionnaire): Step[] =
   })
 }
 
-const autocompleteStepIvrPrompt = (state, action, quiz: Questionnaire): Step[] => {
+const autocompleteStepIvrPrompt = (state, action) => {
   return changeStep(state, action.stepId, step => {
     // First change default language
-    step = setStepPrompt(step, quiz.defaultLanguage, prompt => ({
+    step = setStepPrompt(step, state.defaultLanguage, prompt => ({
       ...prompt,
       ivr: {
         ...prompt.ivr,
@@ -388,9 +456,9 @@ const autocompleteStepIvrPrompt = (state, action, quiz: Questionnaire): Step[] =
   })
 }
 
-const changeStepIvrPrompt = (state, action, quiz: Questionnaire) => {
+const changeStepIvrPrompt = (state, action) => {
   return changeStep(state, action.stepId, step => {
-    return setStepPrompt(step, quiz.activeLanguage, prompt => ({
+    return setStepPrompt(step, state.activeLanguage, prompt => ({
       ...prompt,
       ivr: {
         ...prompt.ivr,
@@ -401,9 +469,9 @@ const changeStepIvrPrompt = (state, action, quiz: Questionnaire) => {
   })
 }
 
-const changeStepIvrAudioId = (state, action, quiz: Questionnaire) => {
+const changeStepIvrAudioId = (state, action) => {
   return changeStep(state, action.stepId, step => {
-    return setStepPrompt(step, quiz.activeLanguage, prompt => ({
+    return setStepPrompt(step, state.activeLanguage, prompt => ({
       ...prompt,
       ivr: {
         ...prompt.ivr,
@@ -504,10 +572,27 @@ const changeStepStore = (state, action) => {
 }
 
 const addStep = (state, action) => {
-  return [
+  return {
     ...state,
-    newMultipleChoiceStep()
-  ]
+    steps: [
+      ...state.steps,
+      newMultipleChoiceStep()
+    ]
+  }
+}
+
+const addQuotaCompletedStep = (state, action) => {
+  if (!state.quotaCompletedSteps) {
+    throw new Error('Bug: expected state.quotaCompletedStepsComponent to be present')
+  }
+
+  return {
+    ...state,
+    quotaCompletedSteps: [
+      ...state.quotaCompletedSteps,
+      newMultipleChoiceStep()
+    ]
+  }
 }
 
 const newLanguageSelectionStep = (first: string, second: string): LanguageSelectionStep => {
@@ -534,6 +619,17 @@ export const newMultipleChoiceStep = () => {
   }
 }
 
+export const newExplanationStep = () => ({
+  id: uuid.v4(),
+  type: 'explanation',
+  title: '',
+  store: '',
+  prompt: {
+    'en': newStepPrompt()
+  },
+  skipLogic: null
+})
+
 const toggleMode = (state, action) => {
   let modes = state.modes
   if (modes.indexOf(action.mode) == -1) {
@@ -545,6 +641,20 @@ const toggleMode = (state, action) => {
   return {
     ...state,
     modes
+  }
+}
+
+const toggleQuotaCompletedSteps = (state, action) => {
+  if (state.quotaCompletedSteps) {
+    return {
+      ...state,
+      quotaCompletedSteps: null
+    }
+  } else {
+    return {
+      ...state,
+      quotaCompletedSteps: [newExplanationStep()]
+    }
   }
 }
 
@@ -565,7 +675,7 @@ const addLanguage = (state, action) => {
     if (state.languages.length == 1) {
       steps = addLanguageSelectionStep(state, action)
     } else {
-      steps = addOptionToLanguageSelectionStep(state, action.language)
+      steps = addOptionToLanguageSelectionStep(state, action.language).steps
     }
     return {
       ...state,
@@ -581,7 +691,7 @@ const removeLanguage = (state, action) => {
   const indexToDelete = state.languages.indexOf(action.language)
   if (indexToDelete != -1) {
     const newLanguages = [...state.languages.slice(0, indexToDelete), ...state.languages.slice(indexToDelete + 1)]
-    let newSteps = removeOptionFromLanguageSelectionStep(state, action.language)
+    let newSteps = removeOptionFromLanguageSelectionStep(state, action.language).steps
 
     // If only one language remains, remove the language-selection
     // step (should be the first one)
@@ -618,13 +728,10 @@ const reorderLanguages = (state, action) => {
       choices.splice(action.index - 1, 0, action.language)
     }
 
-    return {
-      ...state,
-      steps: changeStep(state.steps, state.steps[0].id, (step) => ({
-        ...step,
-        languageChoices: choices
-      }))
-    }
+    return changeStep(state, state.steps[0].id, (step) => ({
+      ...step,
+      languageChoices: choices
+    }))
   } else {
     return state
   }
@@ -806,7 +913,7 @@ const setSurveyAlreadyTakenMessage = (state, action) => {
 }
 
 const addOptionToLanguageSelectionStep = (state, language) => {
-  return changeStep(state.steps, state.steps[0].id, (step) => ({
+  return changeStep(state, state.steps[0].id, (step) => ({
     ...step,
     languageChoices: [
       ...step.languageChoices,
@@ -824,12 +931,12 @@ const removeOptionFromLanguageSelectionStep = (state, language) => {
 
     const newLanguages = [...choices.slice(0, index), ...choices.slice(index + 1)]
 
-    return changeStep(state.steps, languageSelectionStep.id, (step) => ({
+    return changeStep(state, languageSelectionStep.id, (step) => ({
       ...step,
       languageChoices: newLanguages
     }))
   } else {
-    return state.steps
+    return state
   }
 }
 
@@ -884,7 +991,39 @@ export const csvForTranslation = (questionnaire: Questionnaire) => {
   let exported = {}
   let context = {rows, headers, exported}
 
-  questionnaire.steps.forEach(step => {
+  csvStepsTranslations(questionnaire.steps, context, defaultLang)
+
+  if (questionnaire.quotaCompletedSteps) {
+    csvStepsTranslations(questionnaire.quotaCompletedSteps, context, defaultLang)
+  }
+
+  if (questionnaire.settings.errorMessage) {
+    addMessageToCsvForTranslation(questionnaire.settings.errorMessage, defaultLang, context)
+  }
+
+  if (questionnaire.settings.title) {
+    const defaultTitle = questionnaire.settings.title[defaultLang]
+    if (defaultTitle && defaultTitle.trim().length != 0) {
+      addToCsvForTranslation(defaultTitle, context, lang =>
+        questionnaire.settings.title[lang] || ''
+      )
+    }
+  }
+
+  if (questionnaire.settings.surveyAlreadyTakenMessage) {
+    const defaultMessage = questionnaire.settings.surveyAlreadyTakenMessage[defaultLang]
+    if (defaultMessage && defaultMessage.trim().length != 0) {
+      addToCsvForTranslation(defaultMessage, context, lang =>
+        questionnaire.settings.surveyAlreadyTakenMessage[lang] || ''
+      )
+    }
+  }
+
+  return rows
+}
+
+const csvStepsTranslations = (steps, context, defaultLang) => {
+  steps.forEach(step => {
     if (step.type !== 'language-selection') {
       // Sms Prompt
       let defaultSms = getStepPromptSms(step, defaultLang)
@@ -916,42 +1055,6 @@ export const csvForTranslation = (questionnaire: Questionnaire) => {
       }
     }
   })
-
-  if (questionnaire.settings.quotaCompletedMessage) {
-    addMessageToCsvForTranslation(questionnaire.settings.quotaCompletedMessage, defaultLang, context)
-  }
-
-  if (questionnaire.settings.errorMessage) {
-    addMessageToCsvForTranslation(questionnaire.settings.errorMessage, defaultLang, context)
-  }
-
-  if (questionnaire.settings.title) {
-    const defaultTitle = questionnaire.settings.title[defaultLang]
-    if (defaultTitle && defaultTitle.trim().length != 0) {
-      addToCsvForTranslation(defaultTitle, context, lang => {
-        if (questionnaire.settings.title && questionnaire.settings.title[lang]) {
-          return questionnaire.settings.title[lang]
-        } else {
-          return ''
-        }
-      })
-    }
-  }
-
-  if (questionnaire.settings.surveyAlreadyTakenMessage) {
-    const defaultMessage = questionnaire.settings.surveyAlreadyTakenMessage[defaultLang]
-    if (defaultMessage && defaultMessage.trim().length != 0) {
-      addToCsvForTranslation(defaultMessage, context, lang => {
-        if (questionnaire.settings.surveyAlreadyTakenMessage && questionnaire.settings.surveyAlreadyTakenMessage[lang]) {
-          return questionnaire.settings.surveyAlreadyTakenMessage[lang]
-        } else {
-          return ''
-        }
-      })
-    }
-  }
-
-  return rows
 }
 
 const addMessageToCsvForTranslation = (m, defaultLang, context) => {
@@ -1137,7 +1240,7 @@ const toggleAcceptsRefusals = (state, action) => {
   })
 }
 
-const changeRefusal = (state, action, quiz) => {
+const changeRefusal = (state, action) => {
   return changeStep(state, action.stepId, step => {
     return {
       ...step,
@@ -1147,11 +1250,11 @@ const changeRefusal = (state, action, quiz) => {
           ivr: splitValues(action.ivrValues),
           sms: {
             ...step.refusal.responses.sms,
-            [quiz.activeLanguage]: splitValues(action.smsValues)
+            [state.activeLanguage]: splitValues(action.smsValues)
           },
           mobileweb: {
             ...step.refusal.responses.mobileweb,
-            [quiz.activeLanguage]: action.mobilewebValues
+            [state.activeLanguage]: action.mobilewebValues
           }
         },
         skipLogic: action.skipLogic
@@ -1176,11 +1279,16 @@ const uploadCsvForTranslation = (state, action) => {
   let newState = {
     ...state,
     settings: {...state.settings},
-    steps: state.steps.map(step => translateStep(step, defaultLanguage, lookup))
+    steps: translateSteps(state.steps, defaultLanguage, lookup)
   }
-  if (state.settings.quotaCompletedMessage) {
-    newState.settings.quotaCompletedMessage = translatePrompt(state.settings.quotaCompletedMessage, defaultLanguage, lookup)
+
+  if (state.quotaCompletedSteps) {
+    newState = {
+      ...newState,
+      quotaCompletedSteps: translateSteps(state.quotaCompletedSteps, defaultLanguage, lookup)
+    }
   }
+
   if (state.settings.errorMessage) {
     newState.settings.errorMessage = translatePrompt(state.settings.errorMessage, defaultLanguage, lookup)
   }
@@ -1191,6 +1299,10 @@ const uploadCsvForTranslation = (state, action) => {
     newState.settings.surveyAlreadyTakenMessage = translateLanguage(state.settings.surveyAlreadyTakenMessage, defaultLanguage, lookup)
   }
   return newState
+}
+
+const translateSteps = (steps, defaultLanguage, lookup) => {
+  return steps.map(step => translateStep(step, defaultLanguage, lookup))
 }
 
 const translateStep = (step, defaultLanguage, lookup): Step => {

--- a/web/static/js/reducers/questionnaire.validation.js
+++ b/web/static/js/reducers/questionnaire.validation.js
@@ -26,9 +26,12 @@ export const validate = (state: DataStore<Questionnaire>) => {
 
   validateSteps(data.steps, context, 'steps')
 
+  if (data.quotaCompletedSteps) {
+    validateSteps(data.quotaCompletedSteps, context, 'quotaCompletedSteps')
+  }
+
   validateMessage('errorMessage', data.settings.errorMessage, context)
   validateThankYouMessage(data.settings.thankYouMessage, context)
-  validateMessage('quotaCompletedMessage', data.settings.quotaCompletedMessage, context)
 
   validateTitle(data, context)
   validateMobileWebSmsMessage(data, context)

--- a/web/views/questionnaire_view.ex
+++ b/web/views/questionnaire_view.ex
@@ -16,6 +16,7 @@ defmodule Ask.QuestionnaireView do
       updated_at: questionnaire.updated_at,
       project_id: questionnaire.project_id,
       steps: questionnaire.steps,
+      quota_completed_steps: questionnaire.quota_completed_steps,
       default_language: questionnaire.default_language,
       languages: questionnaire.languages,
       settings: questionnaire.settings,


### PR DESCRIPTION
**Ready for review** :tada:

The following changes were made to support quota completed steps.

## Data

There's a migration that turns the existing "quota completed message" to a single explanation step in the "quota completed steps".

## UI

So far the UI shows a toggle for showing/hiding the quota completed steps. When the toggle goes from "off" to "on", a default quota completed step is added: an empty explanation. When it goes from "on" to "off" the steps are removed (the `quotaCompletedSteps` property is set to `null`).

To implement the UI and reuse most of the code I changed the questionnaire reducer so that `changeStep` would try to find a step by id in `questionnaire.steps`, and if it's not found try to find it in `questionnaire.quotaCompletedSteps`. That takes care of all the actions related to modifying a step, like changing it's title, prompt or choices. An action that's different is `addStep`, for which now we also have `addQuotaCompletedStep`.

Validations already work for the quota completed steps, as well as downloading and uploading translations (quota completed steps are taken into account).

The step list for the `quotaCompletedSteps` has a `quotaCompletedSteps=true` property so that a "flag" step cannot be chosen as a step type there.

Drag&Drop works in each step list and you can't drag between lists and there's no indication of such possibility, which is the expected behaviour.

## Runtime

The `Flow` structs gains a new `in_quota_completed` bool. When the quota is reached, and this flag is not `true`, the flag is set to `true`, the current step is reset to `nil` and the execution continues. When `in_quota_completed` is `true` the steps used are `flow.questionnaire.quota_completed_steps` instead of `flow.questionnaire.steps`.

I also had to change `Session` to set the state and disposition of a respondent to `rejected` right there, because the reply `{:rejected, ...}` is now no longer possible if there are quota completed steps, because the flow must continue from the quota completed steps. But `Session` already updates a respondent regarding quotas, so I think this is OK.

I tried it on mobile web and it worked well :-)