### PR TITLE
Fixes #1072. Rename failed output in file reports

### DIFF
--- a/lib/ask/runtime/verboice_channel.ex
+++ b/lib/ask/runtime/verboice_channel.ex
@@ -143,12 +143,24 @@ defmodule Ask.Runtime.VerboiceChannel do
     end)
   end
 
+  defp channel_failed(respondent, "failed", %{"CallStatusReason" => reason, "CallStatusCode" => code}) do
+    Broker.channel_failed(respondent, "#{reason} (#{code})")
+  end
+
   defp channel_failed(respondent, status, %{"CallStatusReason" => reason, "CallStatusCode" => code}) do
     Broker.channel_failed(respondent, "#{status}: #{reason} (#{code})")
   end
 
+  defp channel_failed(respondent, "failed", %{"CallStatusReason" => reason}) do
+    Broker.channel_failed(respondent, "#{reason}")
+  end
+
   defp channel_failed(respondent, status, %{"CallStatusReason" => reason}) do
     Broker.channel_failed(respondent, "#{status}: #{reason}")
+  end
+
+  defp channel_failed(respondent, "failed", %{"CallStatusCode" => code}) do
+    Broker.channel_failed(respondent, "(#{code})")
   end
 
   defp channel_failed(respondent, status, %{"CallStatusCode" => code}) do

--- a/test/lib/runtime/verboice_channel_test.exs
+++ b/test/lib/runtime/verboice_channel_test.exs
@@ -148,7 +148,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       assert [call_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
 
       assert call_failed.survey_id == survey.id
-      assert call_failed.action_data == "failed: some random reason (42)"
+      assert call_failed.action_data == "some random reason (42)"
       assert call_failed.action_type == "contact"
 
       :ok = broker |> GenServer.stop
@@ -182,7 +182,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       assert [call_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
 
       assert call_failed.survey_id == survey.id
-      assert call_failed.action_data == "failed (42)"
+      assert call_failed.action_data == "(42)"
       assert call_failed.action_type == "contact"
 
       :ok = broker |> GenServer.stop
@@ -217,7 +217,7 @@ defmodule Ask.Runtime.VerboiceChannelTest do
       assert [call_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
 
       assert call_failed.survey_id == survey.id
-      assert call_failed.action_data == "failed: some random reason"
+      assert call_failed.action_data == "some random reason"
       assert call_failed.action_type == "contact"
 
       :ok = broker |> GenServer.stop


### PR DESCRIPTION
Connects to #1072 