### PR TITLE
Fixes #1024. Step disappears while dragging

### DIFF
--- a/web/static/js/components/questionnaires/ExplanationStepEditor.jsx
+++ b/web/static/js/components/questionnaires/ExplanationStepEditor.jsx
@@ -6,7 +6,6 @@ import StepTypeSelector from './StepTypeSelector'
 import * as questionnaireActions from '../../actions/questionnaire'
 import StepPrompts from './StepPrompts'
 import StepCard from './StepCard'
-import DraggableStep from './DraggableStep'
 import StepDeleteButton from './StepDeleteButton'
 import SkipLogic from './SkipLogic'
 import propsAreEqual from '../../propsAreEqual'
@@ -67,35 +66,33 @@ class ExplanationStepEditor extends Component {
     const { step, stepIndex, onCollapse, stepsAfter, stepsBefore, onDelete, errorPath, errorsByPath, isNew, readOnly, quotaCompletedSteps } = this.props
 
     return (
-      <DraggableStep step={step} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps}>
-        <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle} icon={<StepTypeSelector stepType={step.type} stepId={step.id} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps} />} >
-          <StepPrompts
-            step={step}
-            readOnly={readOnly}
-            stepIndex={stepIndex}
-            errorPath={errorPath}
-            errorsByPath={errorsByPath}
-            isNew={isNew}
-            classes='no-separator'
-            title='Message'
-          />
-          <li className='collection-item' key='editor'>
-            <div className='row'>
-              <div className='col s6'>
-                <SkipLogic
-                  onChange={skipOption => this.skipLogicChange(skipOption)}
-                  readOnly={readOnly}
-                  value={step.skipLogic}
-                  stepsAfter={stepsAfter}
-                  stepsBefore={stepsBefore}
-                  label='Skip logic'
-                />
-              </div>
+      <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle} icon={<StepTypeSelector stepType={step.type} stepId={step.id} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps} />} >
+        <StepPrompts
+          step={step}
+          readOnly={readOnly}
+          stepIndex={stepIndex}
+          errorPath={errorPath}
+          errorsByPath={errorsByPath}
+          isNew={isNew}
+          classes='no-separator'
+          title='Message'
+        />
+        <li className='collection-item' key='editor'>
+          <div className='row'>
+            <div className='col s6'>
+              <SkipLogic
+                onChange={skipOption => this.skipLogicChange(skipOption)}
+                readOnly={readOnly}
+                value={step.skipLogic}
+                stepsAfter={stepsAfter}
+                stepsBefore={stepsBefore}
+                label='Skip logic'
+              />
             </div>
-          </li>
-          {readOnly ? null : <StepDeleteButton onDelete={onDelete} /> }
-        </StepCard>
-      </DraggableStep>
+          </div>
+        </li>
+        {readOnly ? null : <StepDeleteButton onDelete={onDelete} /> }
+      </StepCard>
     )
   }
 }

--- a/web/static/js/components/questionnaires/FlagStepEditor.jsx
+++ b/web/static/js/components/questionnaires/FlagStepEditor.jsx
@@ -5,7 +5,6 @@ import { connect } from 'react-redux'
 import StepTypeSelector from './StepTypeSelector'
 import * as questionnaireActions from '../../actions/questionnaire'
 import StepCard from './StepCard'
-import DraggableStep from './DraggableStep'
 import StepDeleteButton from './StepDeleteButton'
 import SkipLogic from './SkipLogic'
 import propsAreEqual from '../../propsAreEqual'
@@ -76,83 +75,81 @@ class FlagStepEditor extends Component {
     const { step, onCollapse, stepsAfter, stepsBefore, onDelete, readOnly } = this.props
 
     return (
-      <DraggableStep step={step} readOnly={readOnly} quotaCompletedSteps={false}>
-        <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle} icon={<StepTypeSelector stepType={step.type} stepId={step.id} readOnly={readOnly} />} >
-          <li className='collection-item' key='dispositions'>
-            <h5>Disposition</h5>
-            <p><b>Choose the disposition you want to set at this point of the questionnaire.</b></p>
-            <div className='row'>
-              <div className='col s6'>
-                <p>
-                  <input
-                    id={`${step.id}_disposition_partial`}
-                    type='radio'
-                    name='questionnaire_disposition'
-                    className='with-gap'
-                    value='partial'
-                    checked={this.state.disposition == 'partial'}
-                    onChange={e => this.dispositionChange('partial')}
-                    disabled={readOnly}
-                  />
-                  <label htmlFor={`${step.id}_disposition_partial`}>Partial</label>
-                </p>
-                <p>
-                  <input
-                    id={`${step.id}_disposition_ineligible`}
-                    type='radio'
-                    name='questionnaire_disposition'
-                    className='with-gap'
-                    value='ineligible'
-                    checked={this.state.disposition == 'ineligible'}
-                    onChange={e => this.dispositionChange('ineligible')}
-                    disabled={readOnly}
-                  />
-                  <label htmlFor={`${step.id}_disposition_ineligible`}>Ineligible</label>
-                </p>
-                <p>
-                  <input
-                    id={`${step.id}_disposition_refused`}
-                    type='radio'
-                    name='questionnaire_disposition'
-                    className='with-gap'
-                    value='refused'
-                    checked={this.state.disposition == 'refused'}
-                    onChange={e => this.dispositionChange('refused')}
-                    disabled={readOnly}
-                  />
-                  <label htmlFor={`${step.id}_disposition_refused`}>Refused</label>
-                </p>
-                <p>
-                  <input
-                    id={`${step.id}_disposition_completed`}
-                    type='radio'
-                    name='questionnaire_disposition'
-                    className='with-gap'
-                    value='completed'
-                    checked={this.state.disposition == 'completed'}
-                    onChange={e => this.dispositionChange('completed')}
-                    disabled={readOnly}
-                  />
-                  <label htmlFor={`${step.id}_disposition_completed`}>Completed</label>
-                </p>
-              </div>
-            </div>
-            <div className='row'>
-              <div className='col s6'>
-                <SkipLogic
-                  onChange={skipOption => this.skipLogicChange(skipOption)}
-                  readOnly={readOnly}
-                  value={step.skipLogic}
-                  stepsAfter={stepsAfter}
-                  stepsBefore={stepsBefore}
-                  label='Skip logic'
+      <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle} icon={<StepTypeSelector stepType={step.type} stepId={step.id} readOnly={readOnly} />} >
+        <li className='collection-item' key='dispositions'>
+          <h5>Disposition</h5>
+          <p><b>Choose the disposition you want to set at this point of the questionnaire.</b></p>
+          <div className='row'>
+            <div className='col s6'>
+              <p>
+                <input
+                  id={`${step.id}_disposition_partial`}
+                  type='radio'
+                  name='questionnaire_disposition'
+                  className='with-gap'
+                  value='partial'
+                  checked={this.state.disposition == 'partial'}
+                  onChange={e => this.dispositionChange('partial')}
+                  disabled={readOnly}
                 />
-              </div>
+                <label htmlFor={`${step.id}_disposition_partial`}>Partial</label>
+              </p>
+              <p>
+                <input
+                  id={`${step.id}_disposition_ineligible`}
+                  type='radio'
+                  name='questionnaire_disposition'
+                  className='with-gap'
+                  value='ineligible'
+                  checked={this.state.disposition == 'ineligible'}
+                  onChange={e => this.dispositionChange('ineligible')}
+                  disabled={readOnly}
+                />
+                <label htmlFor={`${step.id}_disposition_ineligible`}>Ineligible</label>
+              </p>
+              <p>
+                <input
+                  id={`${step.id}_disposition_refused`}
+                  type='radio'
+                  name='questionnaire_disposition'
+                  className='with-gap'
+                  value='refused'
+                  checked={this.state.disposition == 'refused'}
+                  onChange={e => this.dispositionChange('refused')}
+                  disabled={readOnly}
+                />
+                <label htmlFor={`${step.id}_disposition_refused`}>Refused</label>
+              </p>
+              <p>
+                <input
+                  id={`${step.id}_disposition_completed`}
+                  type='radio'
+                  name='questionnaire_disposition'
+                  className='with-gap'
+                  value='completed'
+                  checked={this.state.disposition == 'completed'}
+                  onChange={e => this.dispositionChange('completed')}
+                  disabled={readOnly}
+                />
+                <label htmlFor={`${step.id}_disposition_completed`}>Completed</label>
+              </p>
             </div>
-          </li>
-          {readOnly ? null : <StepDeleteButton onDelete={onDelete} /> }
-        </StepCard>
-      </DraggableStep>
+          </div>
+          <div className='row'>
+            <div className='col s6'>
+              <SkipLogic
+                onChange={skipOption => this.skipLogicChange(skipOption)}
+                readOnly={readOnly}
+                value={step.skipLogic}
+                stepsAfter={stepsAfter}
+                stepsBefore={stepsBefore}
+                label='Skip logic'
+              />
+            </div>
+          </div>
+        </li>
+        {readOnly ? null : <StepDeleteButton onDelete={onDelete} /> }
+      </StepCard>
     )
   }
 }

--- a/web/static/js/components/questionnaires/MultipleChoiceStepEditor.jsx
+++ b/web/static/js/components/questionnaires/MultipleChoiceStepEditor.jsx
@@ -7,7 +7,6 @@ import * as questionnaireActions from '../../actions/questionnaire'
 import StepMultipleChoiceEditor from './StepMultipleChoiceEditor'
 import StepPrompts from './StepPrompts'
 import StepCard from './StepCard'
-import DraggableStep from './DraggableStep'
 import StepDeleteButton from './StepDeleteButton'
 import StepStoreVariable from './StepStoreVariable'
 import propsAreEqual from '../../propsAreEqual'
@@ -60,39 +59,37 @@ class MultipleChoiceStepEditor extends Component {
     const { step, stepIndex, onCollapse, questionnaire, readOnly, quotaCompletedSteps, errorPath, errorsByPath, stepsAfter, stepsBefore, onDelete, isNew } = this.props
 
     return (
-      <DraggableStep step={step} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps}>
-        <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle}
-          icon={
-            <StepTypeSelector stepType={step.type} stepId={step.id} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps} />
-          } >
-          <StepPrompts
-            step={step}
-            readOnly={readOnly}
-            stepIndex={stepIndex}
-            errorPath={errorPath}
-            errorsByPath={errorsByPath}
-            isNew={isNew}
-            />
-          <li className='collection-item' key='editor'>
-            <div className='row'>
-              <div className='col s12'>
-                <StepMultipleChoiceEditor
-                  questionnaire={questionnaire}
-                  step={step}
-                  stepIndex={stepIndex}
-                  stepsAfter={stepsAfter}
-                  stepsBefore={stepsBefore}
-                  readOnly={readOnly}
-                  errorPath={errorPath}
-                  errorsByPath={errorsByPath}
-                  isNew={isNew} />
-              </div>
+      <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle}
+        icon={
+          <StepTypeSelector stepType={step.type} stepId={step.id} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps} />
+        } >
+        <StepPrompts
+          step={step}
+          readOnly={readOnly}
+          stepIndex={stepIndex}
+          errorPath={errorPath}
+          errorsByPath={errorsByPath}
+          isNew={isNew}
+          />
+        <li className='collection-item' key='editor'>
+          <div className='row'>
+            <div className='col s12'>
+              <StepMultipleChoiceEditor
+                questionnaire={questionnaire}
+                step={step}
+                stepIndex={stepIndex}
+                stepsAfter={stepsAfter}
+                stepsBefore={stepsBefore}
+                readOnly={readOnly}
+                errorPath={errorPath}
+                errorsByPath={errorsByPath}
+                isNew={isNew} />
             </div>
-          </li>
-          <StepStoreVariable step={step} readOnly={readOnly} errorPath={errorPath} errorsByPath={errorsByPath} />
-          {readOnly ? null : <StepDeleteButton onDelete={onDelete} /> }
-        </StepCard>
-      </DraggableStep>
+          </div>
+        </li>
+        <StepStoreVariable step={step} readOnly={readOnly} errorPath={errorPath} errorsByPath={errorsByPath} />
+        {readOnly ? null : <StepDeleteButton onDelete={onDelete} /> }
+      </StepCard>
     )
   }
 }

--- a/web/static/js/components/questionnaires/NumericStepEditor.jsx
+++ b/web/static/js/components/questionnaires/NumericStepEditor.jsx
@@ -7,7 +7,6 @@ import * as questionnaireActions from '../../actions/questionnaire'
 import StepPrompts from './StepPrompts'
 import StepCard from './StepCard'
 import StepNumericEditor from './StepNumericEditor'
-import DraggableStep from './DraggableStep'
 import StepDeleteButton from './StepDeleteButton'
 import StepStoreVariable from './StepStoreVariable'
 import propsAreEqual from '../../propsAreEqual'
@@ -60,37 +59,35 @@ class NumericStepEditor extends Component {
     const { step, stepIndex, onCollapse, questionnaire, readOnly, quotaCompletedSteps, stepsAfter, stepsBefore, onDelete, errorPath, errorsByPath, isNew } = this.props
 
     return (
-      <DraggableStep step={step} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps}>
-        <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle} icon={<StepTypeSelector stepType={step.type} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps} stepId={step.id} />} >
-          <StepPrompts
-            step={step}
-            readOnly={readOnly}
-            stepIndex={stepIndex}
-            errorPath={errorPath}
-            errorsByPath={errorsByPath}
-            isNew={isNew}
-            />
-          <li className='collection-item' key='editor'>
-            <div className='row'>
-              <div className='col s12'>
-                <StepNumericEditor
-                  questionnaire={questionnaire}
-                  readOnly={readOnly}
-                  step={step}
-                  stepIndex={stepIndex}
-                  stepsAfter={stepsAfter}
-                  stepsBefore={stepsBefore}
-                  errorPath={errorPath}
-                  errorsByPath={errorsByPath}
-                  isNew={isNew}
-                  />
-              </div>
+      <StepCard onCollapse={onCollapse} readOnly={readOnly} stepId={step.id} stepTitle={this.state.stepTitle} icon={<StepTypeSelector stepType={step.type} readOnly={readOnly} quotaCompletedSteps={quotaCompletedSteps} stepId={step.id} />} >
+        <StepPrompts
+          step={step}
+          readOnly={readOnly}
+          stepIndex={stepIndex}
+          errorPath={errorPath}
+          errorsByPath={errorsByPath}
+          isNew={isNew}
+          />
+        <li className='collection-item' key='editor'>
+          <div className='row'>
+            <div className='col s12'>
+              <StepNumericEditor
+                questionnaire={questionnaire}
+                readOnly={readOnly}
+                step={step}
+                stepIndex={stepIndex}
+                stepsAfter={stepsAfter}
+                stepsBefore={stepsBefore}
+                errorPath={errorPath}
+                errorsByPath={errorsByPath}
+                isNew={isNew}
+                />
             </div>
-          </li>
-          <StepStoreVariable step={step} readOnly={readOnly} errorPath={errorPath} errorsByPath={errorsByPath} />
-          {readOnly ? null : <StepDeleteButton onDelete={onDelete} /> }
-        </StepCard>
-      </DraggableStep>
+          </div>
+        </li>
+        <StepStoreVariable step={step} readOnly={readOnly} errorPath={errorPath} errorsByPath={errorsByPath} />
+        {readOnly ? null : <StepDeleteButton onDelete={onDelete} /> }
+      </StepCard>
     )
   }
 }


### PR DESCRIPTION
The bug is induced by materializecss. It applies a property left: -9999px
to checkboxes and radio buttons, contained in numeric and flag steps
respectively. That left property is what produce the bug. That is,
drag and drop failing for that kind of steps.

In order to avoid any kind of hack, we took the decision of
remove drag and drop for step editors (a.k.a, expanded steps).

Connects to #1024 