### PR TITLE
Fixes #1170 Allow role for collaborators to be set to "Admin"

### DIFF
--- a/test/controllers/invite_controller_test.exs
+++ b/test/controllers/invite_controller_test.exs
@@ -45,6 +45,22 @@ defmodule Ask.InviteControllerTest do
     end
   end
 
+  test "allows admin to invite", %{conn: conn, user: user} do
+    project = create_project_for_user(user, level: "admin")
+    code = "ABC1234"
+    level = "admin"
+    email = "user@instedd.org"
+    conn = get conn, invite_path(conn, :invite, %{"code" => code, "level" => level, "email" => email, "project_id" => project.id})
+    assert json_response(conn, 201) == %{
+      "data" => %{
+        "project_id" => project.id,
+        "code" => code,
+        "level" => level,
+        "email" => email
+      }
+    }
+  end
+
   test "invites user as reader", %{conn: conn, user: user} do
     project = create_project_for_user(user)
     code = "ABC1234"
@@ -65,6 +81,22 @@ defmodule Ask.InviteControllerTest do
     project = create_project_for_user(user)
     code = "ABC1234"
     level = "editor"
+    email = "user@instedd.org"
+    conn = get conn, invite_path(conn, :invite, %{"code" => code, "level" => level, "email" => email, "project_id" => project.id})
+    assert json_response(conn, 201) == %{
+      "data" => %{
+        "project_id" => project.id,
+        "code" => code,
+        "level" => level,
+        "email" => email
+      }
+    }
+  end
+
+  test "invites user as admin", %{conn: conn, user: user} do
+    project = create_project_for_user(user)
+    code = "ABC1234"
+    level = "admin"
     email = "user@instedd.org"
     conn = get conn, invite_path(conn, :invite, %{"code" => code, "level" => level, "email" => email, "project_id" => project.id})
     assert json_response(conn, 201) == %{

--- a/test/controllers/membership_controller_test.exs
+++ b/test/controllers/membership_controller_test.exs
@@ -90,6 +90,46 @@ defmodule Ask.MembershipControllerTest do
     end
   end
 
+  test "forbids editor to upgrade other to owner", %{conn: conn, user: user} do
+    collaborator_email = "user2@surveda.instedd.org"
+    collaborator = insert(:user, name: "user2", email: collaborator_email)
+
+    project = create_project_for_user(collaborator)
+
+    user_membership = %{"user_id" => user.id, "project_id" => project.id, "level" => "editor"}
+    ProjectMembership.changeset(%ProjectMembership{}, user_membership) |> Repo.insert
+
+    assert_error_sent :forbidden, fn ->
+      put conn, project_membership_update_path(conn, :update, project.id), email: user.email, level: "owner"
+    end
+  end
+
+  test "forbids reader to upgrade other to editor", %{conn: conn, user: user} do
+    collaborator_email = "user2@surveda.instedd.org"
+    collaborator = insert(:user, name: "user2", email: collaborator_email)
+
+    project = create_project_for_user(collaborator)
+
+    user_membership = %{"user_id" => user.id, "project_id" => project.id, "level" => "reader"}
+    ProjectMembership.changeset(%ProjectMembership{}, user_membership) |> Repo.insert
+
+    assert_error_sent :forbidden, fn ->
+      put conn, project_membership_update_path(conn, :update, project.id), email: user.email, level: "editor"
+    end
+  end
+
+  test "forbids editor to update to admin", %{conn: conn, user: user} do
+    project = create_project_for_user(user, level: "editor")
+    collaborator_email = "user2@surveda.instedd.org"
+    collaborator = insert(:user, name: "user2", email: collaborator_email)
+    collaborator_membership = %{"user_id" => collaborator.id, "project_id" => project.id, "level" => "admin"}
+    ProjectMembership.changeset(%ProjectMembership{}, collaborator_membership) |> Repo.insert
+
+    assert_error_sent :forbidden, fn ->
+      put conn, project_membership_update_path(conn, :update, project.id), email: collaborator_email, level: "admin"
+    end
+  end
+
   test "forbids reader to update", %{conn: conn, user: user} do
     project = create_project_for_user(user, level: "reader")
     collaborator_email = "user2@surveda.instedd.org"

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -41,6 +41,7 @@ defmodule Ask.ProjectControllerTest do
           "read_only" => false,
           "colour_scheme" => "default",
           "owner" => true,
+          "level" => "owner"
         },
         %{
           "id"      => project2.id,
@@ -50,6 +51,7 @@ defmodule Ask.ProjectControllerTest do
           "read_only" => true,
           "colour_scheme" => "default",
           "owner" => false,
+          "level" => "reader"
         }
       ]
     end
@@ -76,21 +78,24 @@ defmodule Ask.ProjectControllerTest do
                           "updated_at" => NaiveDateTime.to_iso8601(project1.updated_at),
                           "read_only" => false,
                           "colour_scheme" => "default",
-                          "owner" => true}
+                          "owner" => true,
+                          "level" => "owner"}
       project_map_2 = %{"id"      => project2.id,
                           "name"    => project2.name,
                           "running_surveys" => 1,
                           "updated_at" => NaiveDateTime.to_iso8601(project2.updated_at),
                           "read_only" => false,
                           "colour_scheme" => "default",
-                          "owner" => true}
+                          "owner" => true,
+                          "level" => "owner"}
       project_map_3 = %{"id"      => project3.id,
                           "name"    => project3.name,
                           "running_surveys" => 0,
                           "updated_at" => NaiveDateTime.to_iso8601(project3.updated_at),
                           "read_only" => false,
                           "colour_scheme" => "default",
-                          "owner" => true}
+                          "owner" => true,
+                          "level" => "owner"}
       assert json_response(conn, 200)["data"] == [project_map_1, project_map_2, project_map_3]
     end
 
@@ -107,7 +112,8 @@ defmodule Ask.ProjectControllerTest do
         "updated_at" => NaiveDateTime.to_iso8601(project.updated_at),
         "read_only" => false,
         "colour_scheme" => "default",
-        "owner" => true}
+        "owner" => true,
+        "level" => "owner"}
     end
 
     test "shows chosen resource as read_only", %{conn: conn, user: user} do
@@ -119,7 +125,8 @@ defmodule Ask.ProjectControllerTest do
         "updated_at" => NaiveDateTime.to_iso8601(project.updated_at),
         "read_only" => true,
         "colour_scheme" => "default",
-        "owner" => false}
+        "owner" => false,
+        "level" => "reader"}
     end
 
     test "renders page not found when id is nonexistent", %{conn: conn} do
@@ -144,7 +151,8 @@ defmodule Ask.ProjectControllerTest do
         "updated_at" => NaiveDateTime.to_iso8601(project.updated_at),
         "read_only" => true,
         "colour_scheme" => "default",
-        "owner" => false}
+        "owner" => false,
+        "level" => "reader"}
     end
 
   end

--- a/web/controllers/membership_controller.ex
+++ b/web/controllers/membership_controller.ex
@@ -1,7 +1,7 @@
 defmodule Ask.MembershipController do
   use Ask.Web, :api_controller
 
-  alias Ask.{Project, ProjectMembership, User}
+  alias Ask.{Project, ProjectMembership, User, UnauthorizedError}
 
   def remove(conn, %{"project_id" => project_id, "email" => email}) do
     user_id = Repo.one(from u in User, where: u.email == ^email, select: u.id)
@@ -22,10 +22,25 @@ defmodule Ask.MembershipController do
     send_resp(conn, :no_content, "")
   end
 
+  def update(conn, %{"level" => "owner"}) do
+    raise UnauthorizedError, conn: conn
+  end
+
+  def update(conn, %{"project_id" => project_id, "level" => "admin", "email" => email}) do
+    conn
+    |> load_project_for_owner(project_id)
+
+    perform_update(conn, project_id, "admin", email)
+  end
+
   def update(conn, %{"project_id" => project_id, "level" => new_level, "email" => email}) do
     conn
     |> load_project_for_change(project_id)
 
+    perform_update(conn, project_id, new_level, email)
+  end
+
+  def perform_update(conn, project_id, new_level, email) do
     user_id = Repo.one(from u in User, where: u.email == ^email, select: u.id)
 
     Repo.one(from m in ProjectMembership, where: m.user_id == ^user_id and m.project_id == ^project_id)

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -25,7 +25,11 @@ defmodule Ask.ProjectController do
           if Enum.any?(memberships, &(&1.level == "editor")) do
             "editor"
           else
-            "reader"
+            if Enum.any?(memberships, &(&1.level == "admin")) do
+              "admin"
+            else
+              "reader"
+            end
           end
         end
       {id, level}
@@ -64,7 +68,7 @@ defmodule Ask.ProjectController do
         conn
         |> put_status(:created)
         |> put_resp_header("location", project_path(conn, :show, project))
-        |> render("show.json", project: project, read_only: false, owner: true)
+        |> render("show.json", project: project, read_only: false, owner: true, level: "owner")
       {:error, changeset} ->
         Logger.warn "Error when creating a new project: #{inspect changeset}"
         conn
@@ -91,7 +95,7 @@ defmodule Ask.ProjectController do
     if membership do
       read_only = membership.level == "reader"
       owner = membership.level == "owner"
-      render(conn, "show.json", project: project, read_only: read_only, owner: owner)
+      render(conn, "show.json", project: project, read_only: read_only, owner: owner, level: membership.level)
     else
       raise Ask.UnauthorizedError, conn: conn
     end
@@ -115,7 +119,7 @@ defmodule Ask.ProjectController do
         |> Repo.one
 
         owner = membership.level == "owner"
-        render(conn, "show.json", project: project, read_only: false, owner: owner)
+        render(conn, "show.json", project: project, read_only: false, owner: owner, level: membership.level)
       {:error, changeset} ->
         Logger.warn "Error when updating project #{project.id}: #{inspect changeset}"
         conn

--- a/web/controllers/survey_controller.ex
+++ b/web/controllers/survey_controller.ex
@@ -362,13 +362,13 @@ defmodule Ask.SurveyController do
           project_survey_respondents_results_path(conn, :results, project, survey, %{"_format" => "csv"})
         }
       "incentives" ->
-        authorize_owner(project, conn)
+        authorize_admin(project, conn)
         {
           Survey.link_name(survey, :incentives),
           project_survey_respondents_incentives_path(conn, :incentives, project, survey, %{"_format" => "csv"})
         }
       "interactions" ->
-        authorize_owner(project, conn)
+        authorize_admin(project, conn)
         {
           Survey.link_name(survey, :interactions),
           project_survey_respondents_interactions_path(conn, :interactions, project, survey, %{"_format" => "csv"})
@@ -401,7 +401,7 @@ defmodule Ask.SurveyController do
     |> load_project_for_change(project_id)
 
     if target_name == "interactions" || target_name == "incentives" do
-      authorize_owner(project, conn)
+      authorize_admin(project, conn)
     end
 
     survey = project
@@ -434,7 +434,7 @@ defmodule Ask.SurveyController do
     |> load_project_for_change(project_id)
 
     if target_name == "interactions" || target_name == "incentives" do
-      authorize_owner(project, conn)
+      authorize_admin(project, conn)
     end
 
     survey = project

--- a/web/helpers/user_helper.ex
+++ b/web/helpers/user_helper.ex
@@ -31,7 +31,7 @@ defmodule User.Helper do
   end
 
   # Checks that the current user belongs to the given project,
-  # as either an owner or editor, but not as a reader.
+  # as either an owner, admin or editor, but not as a reader.
   #
   # Use this method on create, update, delete and other controller actions
   # that perform a change on a resource related to a project.
@@ -39,7 +39,7 @@ defmodule User.Helper do
     user_id = current_user(conn).id
     memberships = project
                   |> assoc(:project_memberships)
-                  |> where([m], m.user_id == ^user_id and (m.level == "owner" or m.level == "editor"))
+                  |> where([m], m.user_id == ^user_id and (m.level == "owner" or m.level == "editor" or m.level == "admin"))
                   |> Repo.all
     case memberships do
       [] -> raise UnauthorizedError, conn: conn
@@ -47,14 +47,15 @@ defmodule User.Helper do
     end
   end
 
-  def authorize_owner(project, %{assigns: %{skip_auth: true}}) do
+  def authorize_admin(project, %{assigns: %{skip_auth: true}}) do
     project
   end
-  def authorize_owner(project, conn) do
+
+  def authorize_admin(project, conn) do
     user_id = current_user(conn).id
     memberships = project
                   |> assoc(:project_memberships)
-                  |> where([m], m.user_id == ^user_id and m.level == "owner")
+                  |> where([m], m.user_id == ^user_id and (m.level == "owner" or m.level == "admin"))
                   |> Repo.all
     case memberships do
       [] -> raise UnauthorizedError, conn: conn
@@ -82,7 +83,7 @@ defmodule User.Helper do
   def load_project_for_owner(conn, project_id) do
     Project
     |> Repo.get!(project_id)
-    |> authorize_owner(conn)
+    |> authorize_admin(conn)
   end
 
   def authorize_channel(channel, conn) do

--- a/web/models/project_membership.ex
+++ b/web/models/project_membership.ex
@@ -2,7 +2,7 @@ defmodule Ask.ProjectMembership do
   use Ask.Web, :model
 
   schema "project_memberships" do
-    field :level, :string # owner, editor, reader
+    field :level, :string # owner, admin, editor, reader
     belongs_to :user, Ask.User
     belongs_to :project, Ask.Project
 

--- a/web/static/js/components/InviteConfirmation.jsx
+++ b/web/static/js/components/InviteConfirmation.jsx
@@ -39,7 +39,7 @@ class InviteConfirmation extends Component {
     }
 
     const inviteText = <span> {`${invite.inviter_email} has invited you to collaborate as ${invite.role} on `}<UntitledIfEmpty text={invite.project_name} entityName='project' /></span>
-    const roleAction = invite.role == 'editor' ? 'manage' : 'see'
+    const roleAction = (invite.role == 'editor' || invite.role == 'admin') ? 'manage' : 'see'
     const roleDescription = <span> { "You'll be able to " + roleAction + ' surveys, questionnaires, content and collaborators'} </span>
 
     return (

--- a/web/static/js/components/collaborators/CollaboratorIndex.jsx
+++ b/web/static/js/components/collaborators/CollaboratorIndex.jsx
@@ -41,8 +41,15 @@ class CollaboratorIndex extends Component {
   }
 
   levelEditor(collaborator, readOnly) {
+    const { userLevel } = this.props
     const disabled = (readOnly || collaborator.role == 'owner')
-    const options = (collaborator.role == 'owner') ? ['owner'] : ['reader', 'editor']
+    var roles = ['editor', 'reader']
+
+    if (userLevel == 'owner' || userLevel == 'admin') {
+      roles = ['admin'].concat(roles)
+    }
+
+    const options = (collaborator.role == 'owner') ? ['owner'] : roles
     return (
       <td className='w-select'>
         <Input type='select'
@@ -138,7 +145,8 @@ CollaboratorIndex.propTypes = {
   actions: PropTypes.object.isRequired,
   inviteActions: PropTypes.object.isRequired,
   guestActions: PropTypes.object.isRequired,
-  projectActions: PropTypes.object.isRequired
+  projectActions: PropTypes.object.isRequired,
+  userLevel: PropTypes.string
 }
 
 const mapDispatchToProps = (dispatch) => ({
@@ -151,6 +159,7 @@ const mapDispatchToProps = (dispatch) => ({
 const mapStateToProps = (state, ownProps) => ({
   projectId: ownProps.params.projectId,
   project: state.project.data,
+  userLevel: state.project.data ? state.project.data.level : '',
   collaborators: state.collaborators.items
 })
 

--- a/web/static/js/components/collaborators/InviteModal.jsx
+++ b/web/static/js/components/collaborators/InviteModal.jsx
@@ -69,7 +69,13 @@ export class InviteModal extends Component {
   }
 
   render() {
-    const { header, modalText, modalId, style, guest } = this.props
+    const { header, modalText, modalId, style, guest, userLevel } = this.props
+
+    var roles = ['editor', 'reader']
+
+    if (userLevel == 'owner' || userLevel == 'admin') {
+      roles = ['admin'].concat(roles)
+    }
 
     if (!guest) {
       return <div>Loading...</div>
@@ -117,7 +123,7 @@ export class InviteModal extends Component {
                 <option value=''>
                 Select a role
                 </option>
-                { ['editor', 'reader'].map((role) =>
+                {roles.map((role) =>
                   <option key={role} value={role}>
                     {startCase(role)}
                   </option>
@@ -154,7 +160,8 @@ InviteModal.propTypes = {
   onConfirm: PropTypes.func.isRequired,
   modalId: PropTypes.string.isRequired,
   projectId: PropTypes.number,
-  style: PropTypes.object
+  style: PropTypes.object,
+  userLevel: PropTypes.string
 }
 
 const mapDispatchToProps = (dispatch) => ({
@@ -165,6 +172,7 @@ const mapDispatchToProps = (dispatch) => ({
 
 const mapStateToProps = (state) => ({
   projectId: state.project.data.id,
+  userLevel: state.project.data.level,
   guest: state.guest
 })
 

--- a/web/static/js/components/respondents/RespondentIndex.jsx
+++ b/web/static/js/components/respondents/RespondentIndex.jsx
@@ -21,6 +21,7 @@ type Props = {
   questionnaires: {[id: any]: Questionnaire},
   respondents: {[id: any]: Respondent},
   order: any[],
+  userLevel: string,
   pageSize: number,
   pageNumber: number,
   totalCount: number,
@@ -248,7 +249,7 @@ class RespondentIndex extends Component {
       return <div>Loading...</div>
     }
 
-    const { survey, questionnaires, project, totalCount, order, sortBy, sortAsc } = this.props
+    const { survey, questionnaires, totalCount, order, sortBy, sortAsc, userLevel } = this.props
 
     const hasComparisons = survey.comparisons.length > 0
 
@@ -318,7 +319,7 @@ class RespondentIndex extends Component {
     }
 
     let incentivesCsvLink = null
-    if (project.owner) {
+    if (userLevel == 'owner' || userLevel == 'admin') {
       incentivesCsvLink = (
         <li className='collection-item'>
           <a href='#' className='download' onClick={e => { e.preventDefault(); this.downloadIncentivesCSV() }}>
@@ -336,7 +337,7 @@ class RespondentIndex extends Component {
     }
 
     let interactionsCsvLink = null
-    if (project.owner) {
+    if (userLevel == 'owner' || userLevel == 'admin') {
       interactionsCsvLink = (
         <li className='collection-item'>
           <a href='#' className='download' onClick={e => { e.preventDefault(); this.downloadInteractionsCSV() }}>
@@ -466,6 +467,7 @@ const mapStateToProps = (state, ownProps) => {
     questionnaires: state.questionnaires.items,
     respondents: state.respondents.items,
     order: state.respondents.order,
+    userLevel: state.project.data ? state.project.data.level : '',
     pageNumber,
     pageSize,
     startIndex,

--- a/web/static/js/reducers/guest.js
+++ b/web/static/js/reducers/guest.js
@@ -40,7 +40,7 @@ const changeEmail = (state, action) => {
 }
 
 const changeLevel = (state, action) => {
-  if (['reader', 'editor'].includes(action.level)) {
+  if (['admin', 'editor', 'reader'].includes(action.level)) {
     return {
       ...state,
       data: {

--- a/web/views/project_view.ex
+++ b/web/views/project_view.ex
@@ -6,17 +6,19 @@ defmodule Ask.ProjectView do
       level = levels_by_project |> Map.get(project.id, "reader")
       one = render_one(project)
       one
-      |> Map.put(:running_surveys, Map.get(running_surveys_by_project, project.id, 0))
-      |> Map.put(:read_only, level == "reader")
-      |> Map.put(:owner, level == "owner")
+        |> Map.put(:running_surveys, Map.get(running_surveys_by_project, project.id, 0))
+        |> Map.put(:read_only, level == "reader")
+        |> Map.put(:owner, level == "owner")
+        |> Map.put(:level, level)
     end)
     %{data: rendered}
   end
 
-  def render("show.json", %{project: project, read_only: read_only, owner: owner}) do
+  def render("show.json", %{project: project, read_only: read_only, owner: owner, level: level}) do
     rendered = render_one(project, Ask.ProjectView, "project.json")
-    |> Map.put(:read_only, read_only)
-    |> Map.put(:owner, owner)
+      |> Map.put(:read_only, read_only)
+      |> Map.put(:owner, owner)
+      |> Map.put(:level, level)
     %{data: rendered}
   end
 


### PR DESCRIPTION
Added admin role to the invitation and collaboratorIndex. Now it validates on the controllers that an user cannot give higher permissions than the ones he has to others
There still are some issues with permissions that I found, so I will create new issues to track that.
Fixed a critical issue that allowed an editor to change the permissions to other user or himself to ‘owner’ (see membership_controller.ex and its tests)