### PR TITLE
Feature/1231 activity survey reports

### DIFF
--- a/priv/repo/migrations/20180312173843_add_remote_ip_to_activity_log.exs
+++ b/priv/repo/migrations/20180312173843_add_remote_ip_to_activity_log.exs
@@ -1,0 +1,15 @@
+defmodule Ask.Repo.Migrations.AddRemoteIpToActivityLog do
+  use Ecto.Migration
+
+  def up do
+    alter table(:activity_log) do
+      add :remote_ip, :string
+    end
+  end
+
+  def down do
+    alter table(:activity_log) do
+      remove :remote_ip
+    end
+  end
+end

--- a/test/controllers/invite_controller_test.exs
+++ b/test/controllers/invite_controller_test.exs
@@ -154,6 +154,10 @@ defmodule Ask.InviteControllerTest do
     code = "ABC1234"
     level = "editor"
     email = "user@instedd.org"
+    remote_ip = {192, 168, 0, 128}
+    remote_ip_string = "192.168.0.128"
+    conn = conn |> Map.put(:remote_ip, remote_ip)
+
     get conn, invite_path(conn, :invite, %{"code" => code, "level" => level, "email" => email, "project_id" => project.id})
     activity_log = ActivityLog |> Repo.one
     assert activity_log.project_id == project.id
@@ -161,6 +165,7 @@ defmodule Ask.InviteControllerTest do
     assert activity_log.entity_id == project.id
     assert activity_log.entity_type == "project"
     assert activity_log.action == "create_invite"
+    assert activity_log.remote_ip == remote_ip_string
 
     assert activity_log.metadata == %{
       "project_name" => project.name,
@@ -192,6 +197,10 @@ defmodule Ask.InviteControllerTest do
     project = create_project_for_user(user)
     code = "ABC1234"
     email = "user@instedd.org"
+    remote_ip = {192, 168, 0, 128}
+    remote_ip_string = "192.168.0.128"
+    conn = conn |> Map.put(:remote_ip, remote_ip)
+
     get conn, invite_path(conn, :invite, %{"code" => code, "level" => "reader", "email" => email, "project_id" => project.id})
     get conn, invite_path(conn, :invite, %{"code" => code, "level" => "editor", "email" => email, "project_id" => project.id})
 
@@ -201,6 +210,7 @@ defmodule Ask.InviteControllerTest do
     assert activity_log.entity_id == project.id
     assert activity_log.entity_type == "project"
     assert activity_log.action == "edit_invite"
+    assert activity_log.remote_ip == remote_ip_string
 
     assert activity_log.metadata == %{
       "project_name" => project.name,
@@ -214,6 +224,7 @@ defmodule Ask.InviteControllerTest do
     project = create_project_for_user(user)
     code = "ABC1234"
     email = "user@instedd.org"
+
     get conn, invite_path(conn, :invite, %{"code" => code, "level" => "reader", "email" => email, "project_id" => project.id})
     get conn, invite_path(conn, :invite, %{"code" => code, "level" => "reader", "email" => email, "project_id" => project.id})
 
@@ -251,7 +262,7 @@ defmodule Ask.InviteControllerTest do
     }
   end
 
-  test "if doesn't generate activity log if an invite already exists and a different code is sent", %{conn: conn, user: user} do
+  test "it doesn't generate activity log if an invite already exists and a different code is sent", %{conn: conn, user: user} do
     project = create_project_for_user(user)
     code = "ABC1234"
     code2 = "ABC1235"
@@ -410,6 +421,9 @@ defmodule Ask.InviteControllerTest do
       "inviter_email" => user.email
     }
     Invite.changeset(%Invite{}, invite) |> Repo.insert
+    remote_ip = {192, 168, 0, 128}
+    remote_ip_string = "192.168.0.128"
+    conn = conn |> Map.put(:remote_ip, remote_ip)
 
     put conn, invite_update_path(conn, :update, %{"project_id" => project.id, "email" => email, "level" => "editor"})
 
@@ -419,6 +433,7 @@ defmodule Ask.InviteControllerTest do
     assert activity_log.entity_id == project.id
     assert activity_log.entity_type == "project"
     assert activity_log.action == "edit_invite"
+    assert activity_log.remote_ip == remote_ip_string
 
     assert activity_log.metadata == %{
       "project_name" => project.name,
@@ -604,6 +619,9 @@ defmodule Ask.InviteControllerTest do
       "inviter_email" => user.email
     }
     Invite.changeset(%Invite{}, invite) |> Repo.insert
+    remote_ip = {192, 168, 0, 128}
+    remote_ip_string = "192.168.0.128"
+    conn = conn |> Map.put(:remote_ip, remote_ip)
 
     delete conn, invite_remove_path(conn, :remove, %{"project_id" => project.id, "email" => email})
 
@@ -613,6 +631,7 @@ defmodule Ask.InviteControllerTest do
     assert activity_log.entity_id == project.id
     assert activity_log.entity_type == "project"
     assert activity_log.action == "delete_invite"
+    assert activity_log.remote_ip == remote_ip_string
 
     assert activity_log.metadata == %{
       "project_name" => project.name,

--- a/test/controllers/membership_controller_test.exs
+++ b/test/controllers/membership_controller_test.exs
@@ -83,6 +83,9 @@ defmodule Ask.MembershipControllerTest do
     collaborator = insert(:user, name: "user2", email: collaborator_email)
     collaborator_membership = %{"user_id" => collaborator.id, "project_id" => project.id, "level" => "editor"}
     ProjectMembership.changeset(%ProjectMembership{}, collaborator_membership) |> Repo.insert
+    remote_ip = {192, 168, 0, 128}
+    remote_ip_string = "192.168.0.128"
+    conn = conn |> Map.put(:remote_ip, remote_ip)
 
     delete conn, project_membership_remove_path(conn, :remove, project.id), email: collaborator_email
 
@@ -92,6 +95,7 @@ defmodule Ask.MembershipControllerTest do
     assert activity_log.entity_id == project.id
     assert activity_log.entity_type == "project"
     assert activity_log.action == "remove_collaborator"
+    assert activity_log.remote_ip == remote_ip_string
 
     assert activity_log.metadata == %{
       "project_name" => project.name,
@@ -221,6 +225,9 @@ defmodule Ask.MembershipControllerTest do
     collaborator = insert(:user, name: "user2", email: collaborator_email)
     collaborator_membership = %{"user_id" => collaborator.id, "project_id" => project.id, "level" => "editor"}
     ProjectMembership.changeset(%ProjectMembership{}, collaborator_membership) |> Repo.insert
+    remote_ip = {192, 168, 0, 128}
+    remote_ip_string = "192.168.0.128"
+    conn = conn |> Map.put(:remote_ip, remote_ip)
 
     put conn, project_membership_update_path(conn, :update, project.id), email: collaborator_email, level: "reader"
 
@@ -230,6 +237,7 @@ defmodule Ask.MembershipControllerTest do
     assert activity_log.entity_id == project.id
     assert activity_log.entity_type == "project"
     assert activity_log.action == "edit_collaborator"
+    assert activity_log.remote_ip == remote_ip_string
 
     assert activity_log.metadata == %{
       "project_name" => project.name,

--- a/test/controllers/survey_controller_test.exs
+++ b/test/controllers/survey_controller_test.exs
@@ -3,7 +3,7 @@ defmodule Ask.SurveyControllerTest do
   use Ask.TestHelpers
   use Ask.DummySteps
 
-  alias Ask.{Survey, Project, RespondentGroup, Respondent, Response, Channel, SurveyQuestionnaire, RespondentDispositionHistory, TestChannel, RespondentGroupChannel, ShortLink}
+  alias Ask.{Survey, Project, RespondentGroup, Respondent, Response, Channel, SurveyQuestionnaire, RespondentDispositionHistory, TestChannel, RespondentGroupChannel, ShortLink, ActivityLog}
   alias Ask.Runtime.{Flow, Session}
   alias Ask.Runtime.SessionModeProvider
 
@@ -1202,6 +1202,23 @@ defmodule Ask.SurveyControllerTest do
       assert [] == ShortLink |> Repo.all()
     end
 
+    test "activity logs for results link", %{conn: conn, user: user} do
+      project = create_project_for_user(user)
+      survey = insert(:survey, project: project)
+
+      get conn, project_survey_links_path(conn, :create_link, project, survey, "results")
+      activity_log_create = ActivityLog |> where([log], log.action == "enable_public_link") |> Repo.one
+      assert_link_log(%{log: activity_log_create, user: user, project: project, survey: survey, action: "enable_public_link", report_type: "survey_results"})
+
+      put conn, project_survey_links_path(conn, :refresh_link, project, survey, "results")
+      activity_log_regenerate = ActivityLog |> where([log], log.action == "regenerate_public_link") |> Repo.one
+      assert_link_log(%{log: activity_log_regenerate, user: user, project: project, survey: survey, action: "regenerate_public_link", report_type: "survey_results"})
+
+      delete conn, project_survey_links_path(conn, :delete_link, project, survey, "results")
+      activity_log_delete = ActivityLog |> where([log], log.action == "disable_public_link") |> Repo.one
+      assert_link_log(%{log: activity_log_delete, user: user, project: project, survey: survey, action: "disable_public_link", report_type: "survey_results"})
+    end
+
     test "incentives link generation", %{conn: conn, user: user} do
       project = create_project_for_user(user)
       survey = insert(:survey, project: project)
@@ -1241,6 +1258,23 @@ defmodule Ask.SurveyControllerTest do
 
       assert response(response, 204)
       assert [] == ShortLink |> Repo.all()
+    end
+
+    test "activity logs for incentives link", %{conn: conn, user: user} do
+      project = create_project_for_user(user)
+      survey = insert(:survey, project: project)
+
+      get conn, project_survey_links_path(conn, :create_link, project, survey, "incentives")
+      activity_log_create = ActivityLog |> where([log], log.action == "enable_public_link") |> Repo.one
+      assert_link_log(%{log: activity_log_create, user: user, project: project, survey: survey, action: "enable_public_link", report_type: "incentives"})
+
+      put conn, project_survey_links_path(conn, :refresh_link, project, survey, "incentives")
+      activity_log_regenerate = ActivityLog |> where([log], log.action == "regenerate_public_link") |> Repo.one
+      assert_link_log(%{log: activity_log_regenerate, user: user, project: project, survey: survey, action: "regenerate_public_link", report_type: "incentives"})
+
+      delete conn, project_survey_links_path(conn, :delete_link, project, survey, "incentives")
+      activity_log_delete = ActivityLog |> where([log], log.action == "disable_public_link") |> Repo.one
+      assert_link_log(%{log: activity_log_delete, user: user, project: project, survey: survey, action: "disable_public_link", report_type: "incentives"})
     end
 
     test "interactions link generation", %{conn: conn, user: user} do
@@ -1284,6 +1318,23 @@ defmodule Ask.SurveyControllerTest do
       assert [] == ShortLink |> Repo.all()
     end
 
+    test "activity logs for interactions link", %{conn: conn, user: user} do
+      project = create_project_for_user(user)
+      survey = insert(:survey, project: project)
+
+      get conn, project_survey_links_path(conn, :create_link, project, survey, "interactions")
+      activity_log_create = ActivityLog |> where([log], log.action == "enable_public_link") |> Repo.one
+      assert_link_log(%{log: activity_log_create, user: user, project: project, survey: survey, action: "enable_public_link", report_type: "interactions"})
+
+      put conn, project_survey_links_path(conn, :refresh_link, project, survey, "interactions")
+      activity_log_regenerate = ActivityLog |> where([log], log.action == "regenerate_public_link") |> Repo.one
+      assert_link_log(%{log: activity_log_regenerate, user: user, project: project, survey: survey, action: "regenerate_public_link", report_type: "interactions"})
+
+      delete conn, project_survey_links_path(conn, :delete_link, project, survey, "interactions")
+      activity_log_delete = ActivityLog |> where([log], log.action == "disable_public_link") |> Repo.one
+      assert_link_log(%{log: activity_log_delete, user: user, project: project, survey: survey, action: "disable_public_link", report_type: "interactions"})
+    end
+
     test "disposition_history link generation", %{conn: conn, user: user} do
       project = create_project_for_user(user)
       survey = insert(:survey, project: project)
@@ -1322,6 +1373,23 @@ defmodule Ask.SurveyControllerTest do
 
       assert response(response, 204)
       assert [] == ShortLink |> Repo.all()
+    end
+
+    test "activity logs for disposition_history link", %{conn: conn, user: user} do
+      project = create_project_for_user(user)
+      survey = insert(:survey, project: project)
+
+      get conn, project_survey_links_path(conn, :create_link, project, survey, "disposition_history")
+      activity_log_create = ActivityLog |> where([log], log.action == "enable_public_link") |> Repo.one
+      assert_link_log(%{log: activity_log_create, user: user, project: project, survey: survey, action: "enable_public_link", report_type: "disposition_history"})
+
+      put conn, project_survey_links_path(conn, :refresh_link, project, survey, "disposition_history")
+      activity_log_regenerate = ActivityLog |> where([log], log.action == "regenerate_public_link") |> Repo.one
+      assert_link_log(%{log: activity_log_regenerate, user: user, project: project, survey: survey, action: "regenerate_public_link", report_type: "disposition_history"})
+
+      delete conn, project_survey_links_path(conn, :delete_link, project, survey, "disposition_history")
+      activity_log_delete = ActivityLog |> where([log], log.action == "disable_public_link") |> Repo.one
+      assert_link_log(%{log: activity_log_delete, user: user, project: project, survey: survey, action: "disable_public_link", report_type: "disposition_history"})
     end
 
     test "forbids readers to create links", %{conn: conn, user: user} do
@@ -1521,5 +1589,18 @@ defmodule Ask.SurveyControllerTest do
     end
     add_respondent_to group
     group
+  end
+
+  defp assert_link_log(%{log: log, user: user, project: project, survey: survey, action: action, report_type: report_type}  ) do
+    assert log.project_id == project.id
+    assert log.user_id == user.id
+    assert log.entity_id == survey.id
+    assert log.entity_type == "survey"
+    assert log.action == action
+
+    assert log.metadata == %{
+      "survey_name" => survey.name,
+      "report_type" => report_type
+    }
   end
 end

--- a/test/controllers/survey_controller_test.exs
+++ b/test/controllers/survey_controller_test.exs
@@ -1206,17 +1206,21 @@ defmodule Ask.SurveyControllerTest do
       project = create_project_for_user(user)
       survey = insert(:survey, project: project)
 
+      remote_ip = {192, 168, 0, 128}
+      remote_ip_string = "192.168.0.128"
+      conn = conn |> Map.put(:remote_ip, remote_ip)
+
       get conn, project_survey_links_path(conn, :create_link, project, survey, "results")
       activity_log_create = ActivityLog |> where([log], log.action == "enable_public_link") |> Repo.one
-      assert_link_log(%{log: activity_log_create, user: user, project: project, survey: survey, action: "enable_public_link", report_type: "survey_results"})
+      assert_link_log(%{log: activity_log_create, user: user, project: project, survey: survey, action: "enable_public_link", report_type: "survey_results", remote_ip: remote_ip_string})
 
       put conn, project_survey_links_path(conn, :refresh_link, project, survey, "results")
       activity_log_regenerate = ActivityLog |> where([log], log.action == "regenerate_public_link") |> Repo.one
-      assert_link_log(%{log: activity_log_regenerate, user: user, project: project, survey: survey, action: "regenerate_public_link", report_type: "survey_results"})
+      assert_link_log(%{log: activity_log_regenerate, user: user, project: project, survey: survey, action: "regenerate_public_link", report_type: "survey_results", remote_ip: remote_ip_string})
 
       delete conn, project_survey_links_path(conn, :delete_link, project, survey, "results")
       activity_log_delete = ActivityLog |> where([log], log.action == "disable_public_link") |> Repo.one
-      assert_link_log(%{log: activity_log_delete, user: user, project: project, survey: survey, action: "disable_public_link", report_type: "survey_results"})
+      assert_link_log(%{log: activity_log_delete, user: user, project: project, survey: survey, action: "disable_public_link", report_type: "survey_results", remote_ip: remote_ip_string})
     end
 
     test "incentives link generation", %{conn: conn, user: user} do
@@ -1264,17 +1268,21 @@ defmodule Ask.SurveyControllerTest do
       project = create_project_for_user(user)
       survey = insert(:survey, project: project)
 
+      remote_ip = {192, 168, 0, 128}
+      remote_ip_string = "192.168.0.128"
+      conn = conn |> Map.put(:remote_ip, remote_ip)
+
       get conn, project_survey_links_path(conn, :create_link, project, survey, "incentives")
       activity_log_create = ActivityLog |> where([log], log.action == "enable_public_link") |> Repo.one
-      assert_link_log(%{log: activity_log_create, user: user, project: project, survey: survey, action: "enable_public_link", report_type: "incentives"})
+      assert_link_log(%{log: activity_log_create, user: user, project: project, survey: survey, action: "enable_public_link", report_type: "incentives", remote_ip: remote_ip_string})
 
       put conn, project_survey_links_path(conn, :refresh_link, project, survey, "incentives")
       activity_log_regenerate = ActivityLog |> where([log], log.action == "regenerate_public_link") |> Repo.one
-      assert_link_log(%{log: activity_log_regenerate, user: user, project: project, survey: survey, action: "regenerate_public_link", report_type: "incentives"})
+      assert_link_log(%{log: activity_log_regenerate, user: user, project: project, survey: survey, action: "regenerate_public_link", report_type: "incentives", remote_ip: remote_ip_string})
 
       delete conn, project_survey_links_path(conn, :delete_link, project, survey, "incentives")
       activity_log_delete = ActivityLog |> where([log], log.action == "disable_public_link") |> Repo.one
-      assert_link_log(%{log: activity_log_delete, user: user, project: project, survey: survey, action: "disable_public_link", report_type: "incentives"})
+      assert_link_log(%{log: activity_log_delete, user: user, project: project, survey: survey, action: "disable_public_link", report_type: "incentives", remote_ip: remote_ip_string})
     end
 
     test "interactions link generation", %{conn: conn, user: user} do
@@ -1322,17 +1330,21 @@ defmodule Ask.SurveyControllerTest do
       project = create_project_for_user(user)
       survey = insert(:survey, project: project)
 
+      remote_ip = {192, 168, 0, 128}
+      remote_ip_string = "192.168.0.128"
+      conn = conn |> Map.put(:remote_ip, remote_ip)
+
       get conn, project_survey_links_path(conn, :create_link, project, survey, "interactions")
       activity_log_create = ActivityLog |> where([log], log.action == "enable_public_link") |> Repo.one
-      assert_link_log(%{log: activity_log_create, user: user, project: project, survey: survey, action: "enable_public_link", report_type: "interactions"})
+      assert_link_log(%{log: activity_log_create, user: user, project: project, survey: survey, action: "enable_public_link", report_type: "interactions", remote_ip: remote_ip_string})
 
       put conn, project_survey_links_path(conn, :refresh_link, project, survey, "interactions")
       activity_log_regenerate = ActivityLog |> where([log], log.action == "regenerate_public_link") |> Repo.one
-      assert_link_log(%{log: activity_log_regenerate, user: user, project: project, survey: survey, action: "regenerate_public_link", report_type: "interactions"})
+      assert_link_log(%{log: activity_log_regenerate, user: user, project: project, survey: survey, action: "regenerate_public_link", report_type: "interactions", remote_ip: remote_ip_string})
 
       delete conn, project_survey_links_path(conn, :delete_link, project, survey, "interactions")
       activity_log_delete = ActivityLog |> where([log], log.action == "disable_public_link") |> Repo.one
-      assert_link_log(%{log: activity_log_delete, user: user, project: project, survey: survey, action: "disable_public_link", report_type: "interactions"})
+      assert_link_log(%{log: activity_log_delete, user: user, project: project, survey: survey, action: "disable_public_link", report_type: "interactions", remote_ip: remote_ip_string})
     end
 
     test "disposition_history link generation", %{conn: conn, user: user} do
@@ -1379,17 +1391,21 @@ defmodule Ask.SurveyControllerTest do
       project = create_project_for_user(user)
       survey = insert(:survey, project: project)
 
+      remote_ip = {192, 168, 0, 128}
+      remote_ip_string = "192.168.0.128"
+      conn = conn |> Map.put(:remote_ip, remote_ip)
+
       get conn, project_survey_links_path(conn, :create_link, project, survey, "disposition_history")
       activity_log_create = ActivityLog |> where([log], log.action == "enable_public_link") |> Repo.one
-      assert_link_log(%{log: activity_log_create, user: user, project: project, survey: survey, action: "enable_public_link", report_type: "disposition_history"})
+      assert_link_log(%{log: activity_log_create, user: user, project: project, survey: survey, action: "enable_public_link", report_type: "disposition_history", remote_ip: remote_ip_string})
 
       put conn, project_survey_links_path(conn, :refresh_link, project, survey, "disposition_history")
       activity_log_regenerate = ActivityLog |> where([log], log.action == "regenerate_public_link") |> Repo.one
-      assert_link_log(%{log: activity_log_regenerate, user: user, project: project, survey: survey, action: "regenerate_public_link", report_type: "disposition_history"})
+      assert_link_log(%{log: activity_log_regenerate, user: user, project: project, survey: survey, action: "regenerate_public_link", report_type: "disposition_history", remote_ip: remote_ip_string})
 
       delete conn, project_survey_links_path(conn, :delete_link, project, survey, "disposition_history")
       activity_log_delete = ActivityLog |> where([log], log.action == "disable_public_link") |> Repo.one
-      assert_link_log(%{log: activity_log_delete, user: user, project: project, survey: survey, action: "disable_public_link", report_type: "disposition_history"})
+      assert_link_log(%{log: activity_log_delete, user: user, project: project, survey: survey, action: "disable_public_link", report_type: "disposition_history", remote_ip: remote_ip_string})
     end
 
     test "forbids readers to create links", %{conn: conn, user: user} do
@@ -1542,6 +1558,8 @@ defmodule Ask.SurveyControllerTest do
     test "forbids editor to delete some links", %{conn: conn, user: user} do
       project = create_project_for_user(user, level: "editor")
       survey = insert(:survey, project: project)
+      get conn, project_survey_links_path(conn, :create_link, project, survey, "results")
+      get conn, project_survey_links_path(conn, :create_link, project, survey, "disposition_history")
 
       response = delete conn, project_survey_links_path(conn, :delete_link, project, survey, "results")
       assert response(response, 204)
@@ -1591,12 +1609,13 @@ defmodule Ask.SurveyControllerTest do
     group
   end
 
-  defp assert_link_log(%{log: log, user: user, project: project, survey: survey, action: action, report_type: report_type}  ) do
+  defp assert_link_log(%{log: log, user: user, project: project, survey: survey, action: action, report_type: report_type, remote_ip: remote_ip}) do
     assert log.project_id == project.id
     assert log.user_id == user.id
     assert log.entity_id == survey.id
     assert log.entity_type == "survey"
     assert log.action == action
+    assert log.remote_ip == remote_ip
 
     assert log.metadata == %{
       "survey_name" => survey.name,

--- a/web/controllers/membership_controller.ex
+++ b/web/controllers/membership_controller.ex
@@ -18,7 +18,7 @@ defmodule Ask.MembershipController do
 
     multi = Multi.new
     |> Multi.delete(:delete, project_membership)
-    |> Multi.insert(:insert, ActivityLog.remove_collaborator(project_membership.project, current_user(conn), user, project_membership.level))
+    |> Multi.insert(:insert, ActivityLog.remove_collaborator(project_membership.project, conn, user, project_membership.level))
     |> Repo.transaction
 
     case multi do
@@ -60,7 +60,7 @@ defmodule Ask.MembershipController do
 
     multi = Multi.new
     |> Multi.update(:update, update_changeset)
-    |> Multi.insert(:insert, ActivityLog.edit_collaborator(project_membership.project, current_user(conn), user, project_membership.level, new_level))
+    |> Multi.insert(:insert, ActivityLog.edit_collaborator(project_membership.project, conn, user, project_membership.level, new_level))
     |> Repo.transaction
 
     case multi do

--- a/web/controllers/survey_controller.ex
+++ b/web/controllers/survey_controller.ex
@@ -1,8 +1,9 @@
 defmodule Ask.SurveyController do
   use Ask.Web, :api_controller
 
-  alias Ask.{Project, Survey, Questionnaire, Logger, RespondentGroup, Respondent, Channel, ShortLink}
+  alias Ask.{Project, Survey, Questionnaire, Logger, RespondentGroup, Respondent, Channel, ShortLink, ActivityLog}
   alias Ask.Runtime.Session
+  alias Ecto.Multi
 
   def index(conn, %{"project_id" => project_id} = params) do
     project = conn
@@ -394,10 +395,15 @@ defmodule Ask.SurveyController do
         |> send_resp(:no_content, target_name)
     end
 
-    case ShortLink.generate_link(name, target) do
-      {:ok, link} ->
+    multi = Multi.new
+    |> Multi.run(:generate_link, fn _ -> ShortLink.generate_link(name, target) end)
+    |> Multi.insert(:log, ActivityLog.enable_public_link(project, current_user(conn), survey, target_name))
+    |> Repo.transaction
+
+    case multi do
+      {:ok, %{generate_link: link}} ->
         render(conn, "link.json", link: link)
-      {:error, changeset} ->
+      {:error, _, changeset, _} ->
         Logger.warn "Error when creating link #{name}"
         conn
         |> put_status(:unprocessable_entity)
@@ -421,10 +427,15 @@ defmodule Ask.SurveyController do
     |> Repo.get_by(name: Survey.link_name(survey, String.to_atom(target_name)))
 
     if link do
-      case ShortLink.regenerate(link) do
-        {:ok, new_link} ->
+      multi = Multi.new
+      |> Multi.run(:regenerate, fn _ -> ShortLink.regenerate(link) end)
+      |> Multi.insert(:log, ActivityLog.regenerate_public_link(project, current_user(conn), survey, target_name))
+      |> Repo.transaction
+
+      case multi do
+        {:ok, %{regenerate: new_link}} ->
           render(conn, "link.json", link: new_link)
-        {:error, changeset} ->
+        {:error, _, changeset, _} ->
           Logger.warn "Error when regenerating results link #{inspect link}"
           conn
           |> put_status(:unprocessable_entity)
@@ -454,10 +465,23 @@ defmodule Ask.SurveyController do
     |> Repo.get_by(name: Survey.link_name(survey, String.to_atom(target_name)))
 
     if link do
-      Repo.delete!(link)
-    end
+      multi = Multi.new
+      |> Multi.delete(:delete, link)
+      |> Multi.insert(:log, ActivityLog.disable_public_link(project, current_user(conn), survey, link))
+      |> Repo.transaction
 
-    send_resp(conn, :no_content, "")
+      case multi do
+        {:ok, _} -> send_resp(conn, :no_content, "")
+        {:error, _, changeset, _} ->
+          Logger.warn "Error when deleting link #{inspect link}"
+          conn
+          |> put_status(:unprocessable_entity)
+          |> render(Ask.ChangesetView, "error.json", changeset: changeset)
+      end
+    else
+      conn
+      |> send_resp(:not_found, "")
+    end
   end
 
   def stop(conn, %{"survey_id" => id}) do

--- a/web/controllers/survey_controller.ex
+++ b/web/controllers/survey_controller.ex
@@ -397,7 +397,7 @@ defmodule Ask.SurveyController do
 
     multi = Multi.new
     |> Multi.run(:generate_link, fn _ -> ShortLink.generate_link(name, target) end)
-    |> Multi.insert(:log, ActivityLog.enable_public_link(project, current_user(conn), survey, target_name))
+    |> Multi.insert(:log, ActivityLog.enable_public_link(project, conn, survey, target_name))
     |> Repo.transaction
 
     case multi do
@@ -429,7 +429,7 @@ defmodule Ask.SurveyController do
     if link do
       multi = Multi.new
       |> Multi.run(:regenerate, fn _ -> ShortLink.regenerate(link) end)
-      |> Multi.insert(:log, ActivityLog.regenerate_public_link(project, current_user(conn), survey, target_name))
+      |> Multi.insert(:log, ActivityLog.regenerate_public_link(project, conn, survey, target_name))
       |> Repo.transaction
 
       case multi do
@@ -467,7 +467,7 @@ defmodule Ask.SurveyController do
     if link do
       multi = Multi.new
       |> Multi.delete(:delete, link)
-      |> Multi.insert(:log, ActivityLog.disable_public_link(project, current_user(conn), survey, link))
+      |> Multi.insert(:log, ActivityLog.disable_public_link(project, conn, survey, link))
       |> Repo.transaction
 
       case multi do

--- a/web/models/activity_log.ex
+++ b/web/models/activity_log.ex
@@ -55,8 +55,8 @@ defmodule Ask.ActivityLog do
     end
   end
 
-  def edit_collaborator(project, user, collaborator, old_role, new_role) do
-    create("edit_collaborator", project, user, project, %{project_name: project.name,
+  def edit_collaborator(project, conn, collaborator, old_role, new_role) do
+    create("edit_collaborator", project, conn, project, %{project_name: project.name,
       collaborator_email: collaborator.email,
       collaborator_name: collaborator.name,
       old_role: old_role,
@@ -64,8 +64,8 @@ defmodule Ask.ActivityLog do
     })
   end
 
-  def remove_collaborator(project, user, collaborator, role) do
-    create("remove_collaborator", project, user, project, %{
+  def remove_collaborator(project, conn, collaborator, role) do
+    create("remove_collaborator", project, conn, project, %{
       project_name: project.name,
       collaborator_email: collaborator.email,
       collaborator_name: collaborator.name,
@@ -73,8 +73,8 @@ defmodule Ask.ActivityLog do
     })
   end
 
-  def edit_invite(project, user, target_email, old_role, new_role) do
-    create("edit_invite", project, user, project, %{
+  def edit_invite(project, conn, target_email, old_role, new_role) do
+    create("edit_invite", project, conn, project, %{
       project_name: project.name,
       collaborator_email: target_email,
       old_role: old_role,
@@ -82,16 +82,16 @@ defmodule Ask.ActivityLog do
     })
   end
 
-  def delete_invite(project, user, target_email, role) do
-    create("delete_invite", project, user, project, %{
+  def delete_invite(project, conn, target_email, role) do
+    create("delete_invite", project, conn, project, %{
       project_name: project.name,
       collaborator_email: target_email,
       role: role
     })
   end
 
-  def create_invite(project, user, target_email, role) do
-    create("create_invite", project, user, project, %{
+  def create_invite(project, conn, target_email, role) do
+    create("create_invite", project, conn, project, %{
       project_name: project.name,
       collaborator_email: target_email,
       role: role

--- a/web/models/short_link.ex
+++ b/web/models/short_link.ex
@@ -20,11 +20,11 @@ defmodule Ask.ShortLink do
   def generate_link(name, target) do
     case Repo.get_by(ShortLink, name: name) do
       nil ->
-        %ShortLink{
+        ShortLink.changeset(%ShortLink{
           name: name,
           target: target,
           hash: random_hash()
-        }
+        })
         |> Repo.insert
       link -> {:ok, link}
     end


### PR DESCRIPTION
Fixes #1231. 
`remote_ip` field is added to `activity_log` table to always keep track of the source of the action, even in those cases where user_id is not present such as downloading a CSV file.