### PR TITLE
Feature/1281 add server pagination for activities

### DIFF
--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -392,7 +392,7 @@ defmodule Ask.ProjectControllerTest do
       enable_link_log = ActivityLog |> Repo.get!(enable_link_id)
 
       conn = get conn, project_activities_path(conn, :activities, project.id)
-      assert json_response(conn, 200)["data"] == [
+      assert json_response(conn, 200)["data"]["activities"] == [
         %{"user_name" => user.name,
           "action" => "create_invite",
           "entity_type" => "project",
@@ -417,6 +417,7 @@ defmodule Ask.ProjectControllerTest do
           }
         }
       ]
+      assert json_response(conn, 200)["meta"]["count"] == 2
     end
 
     test "paginates activities", %{conn: conn, user: user} do
@@ -430,8 +431,10 @@ defmodule Ask.ProjectControllerTest do
       first_page = get conn, project_activities_path(conn, :activities, project.id, page: 1, limit: 2)
       second_page = get conn, project_activities_path(conn, :activities, project.id, page: 2, limit: 2)
 
-      assert (json_response(first_page, 200)["data"] |> Enum.map(&(&1["action"]))) == ["create_invite", "edit_collaborator"]
-      assert (json_response(second_page, 200)["data"] |> Enum.map(&(&1["action"]))) == ["enable_public_link", "start"]
+      assert (json_response(first_page, 200)["data"]["activities"] |> Enum.map(&(&1["action"]))) == ["create_invite", "edit_collaborator"]
+      assert (json_response(first_page, 200)["meta"]["count"] == 4)
+      assert (json_response(second_page, 200)["data"]["activities"] |> Enum.map(&(&1["action"]))) == ["enable_public_link", "start"]
+      assert (json_response(second_page, 200)["meta"]["count"] == 4)
     end
 
     test "sort activities by insertedAt in ascendent order", %{conn: conn, user: user} do
@@ -445,8 +448,10 @@ defmodule Ask.ProjectControllerTest do
       first_page = get conn, project_activities_path(conn, :activities, project.id, page: 1, limit: 2, sort_by: "insertedAt", sort_asc: true)
       second_page = get conn, project_activities_path(conn, :activities, project.id, page: 2, limit: 2, sort: "insertedAt", sort_asc: true)
 
-      assert (json_response(first_page, 200)["data"] |> Enum.map(&(&1["action"]))) == ["create_invite", "edit_collaborator"]
-      assert (json_response(second_page, 200)["data"] |> Enum.map(&(&1["action"]))) == ["enable_public_link", "start"]
+      assert (json_response(first_page, 200)["data"]["activities"] |> Enum.map(&(&1["action"]))) == ["create_invite", "edit_collaborator"]
+      assert (json_response(first_page, 200)["meta"]["count"] == 4)
+      assert (json_response(second_page, 200)["data"]["activities"] |> Enum.map(&(&1["action"]))) == ["enable_public_link", "start"]
+      assert (json_response(second_page, 200)["meta"]["count"] == 4)
     end
 
     test "sort activities by insertedAt in descendent order", %{conn: conn, user: user} do
@@ -460,8 +465,10 @@ defmodule Ask.ProjectControllerTest do
       first_page = get conn, project_activities_path(conn, :activities, project.id, page: 1, limit: 2, sort_by: "insertedAt", sort_asc: false)
       second_page = get conn, project_activities_path(conn, :activities, project.id, page: 2, limit: 2, sort_by: "insertedAt", sort_asc: false)
 
-      assert (json_response(first_page, 200)["data"] |> Enum.map(&(&1["action"]))) == ["start", "enable_public_link"]
-      assert (json_response(second_page, 200)["data"] |> Enum.map(&(&1["action"]))) == ["edit_collaborator", "create_invite"]
+      assert (json_response(first_page, 200)["data"]["activities"] |> Enum.map(&(&1["action"]))) == ["start", "enable_public_link"]
+      assert (json_response(first_page, 200)["meta"]["count"] == 4)
+      assert (json_response(second_page, 200)["data"]["activities"] |> Enum.map(&(&1["action"]))) == ["edit_collaborator", "create_invite"]
+      assert (json_response(second_page, 200)["meta"]["count"] == 4)
     end
 
     test "doesn't list activities of other project", %{conn: conn, user: user} do
@@ -475,7 +482,7 @@ defmodule Ask.ProjectControllerTest do
       create_invite_log = ActivityLog |> Repo.get!(create_invite_id)
 
       conn = get conn, project_activities_path(conn, :activities, project.id)
-      assert json_response(conn, 200)["data"] == [
+      assert json_response(conn, 200)["data"]["activities"] == [
         %{"user_name" => user.name,
           "action" => "create_invite",
           "entity_type" => "project",

--- a/test/controllers/project_controller_test.exs
+++ b/test/controllers/project_controller_test.exs
@@ -381,33 +381,24 @@ defmodule Ask.ProjectControllerTest do
   end
 
   describe "activity logs" do
-    setup %{conn: conn, user: user} do
-      remote_ip = {192, 168, 0, 128}
-      # current_user is set in conn because it is used in ActivityLog helpers to create changesets
-      conn = %{conn | assigns: %{current_user: user}, remote_ip: remote_ip}
-      {:ok, conn: conn}
-    end
-
     test "lists activities", %{conn: conn, user: user} do
       project = create_project_for_user(user)
       survey = insert(:survey, project: project)
       collaborator_email = "foo@foo.com"
 
-      ActivityLog.create_invite(project, conn, collaborator_email, "editor") |> Repo.insert
-      ActivityLog.enable_public_link(project, conn, survey, "results") |> Repo.insert
-
-      invite_log = ActivityLog |> where([log], log.action == "create_invite") |> Repo.one
-      link_log = ActivityLog |> where([log], log.action == "enable_public_link") |> Repo.one
-
+      %{id: create_invite_id} = insert(:activity_log, project: project, user: user, entity_type: "project", entity_id: project.id, action: "create_invite", inserted_at: Ecto.DateTime.cast!("2000-01-01 00:00:00"), metadata: %{project_name: project.name, collaborator_email: collaborator_email, role: "editor"})
+      %{id: enable_link_id} = insert(:activity_log, project: project, action: "enable_public_link", inserted_at: Ecto.DateTime.cast!("2000-01-02 00:00:00"), user: user, entity_type: "survey", entity_id: survey.id, metadata: %{survey_name: survey.name, report_type: "survey_results"})
+      create_invite_log = ActivityLog |> Repo.get!(create_invite_id)
+      enable_link_log = ActivityLog |> Repo.get!(enable_link_id)
 
       conn = get conn, project_activities_path(conn, :activities, project.id)
       assert json_response(conn, 200)["data"] == [
         %{"user_name" => user.name,
           "action" => "create_invite",
           "entity_type" => "project",
-          "id" => invite_log.id,
-          "inserted_at" => NaiveDateTime.to_iso8601(invite_log.inserted_at),
-          "remote_ip" => "192.168.0.128",
+          "id" => create_invite_id,
+          "inserted_at" => NaiveDateTime.to_iso8601(create_invite_log.inserted_at),
+          "remote_ip" => "192.168.0.1",
           "metadata" => %{
             "project_name" => project.name,
             "collaborator_email" => collaborator_email,
@@ -417,9 +408,9 @@ defmodule Ask.ProjectControllerTest do
         %{"user_name" => user.name,
           "action" => "enable_public_link",
           "entity_type" => "survey",
-          "id" => link_log.id,
-          "remote_ip" => "192.168.0.128",
-          "inserted_at" => NaiveDateTime.to_iso8601(link_log.inserted_at),
+          "id" => enable_link_id,
+          "remote_ip" => "192.168.0.1",
+          "inserted_at" => NaiveDateTime.to_iso8601(enable_link_log.inserted_at),
           "metadata" => %{
             "survey_name" => survey.name,
             "report_type" => "survey_results"
@@ -428,25 +419,69 @@ defmodule Ask.ProjectControllerTest do
       ]
     end
 
+    test "paginates activities", %{conn: conn, user: user} do
+      project = create_project_for_user(user)
+
+      insert(:activity_log, project: project, action: "create_invite", inserted_at: Ecto.DateTime.cast!("2000-01-01 00:00:00"))
+      insert(:activity_log, project: project, action: "edit_collaborator", inserted_at: Ecto.DateTime.cast!("2000-01-02 00:00:00"))
+      insert(:activity_log, project: project, action: "enable_public_link", inserted_at: Ecto.DateTime.cast!("2000-01-03 00:00:00"))
+      insert(:activity_log, project: project, action: "start", inserted_at: Ecto.DateTime.cast!("2000-01-04 00:00:00"))
+
+      first_page = get conn, project_activities_path(conn, :activities, project.id, page: 1, limit: 2)
+      second_page = get conn, project_activities_path(conn, :activities, project.id, page: 2, limit: 2)
+
+      assert (json_response(first_page, 200)["data"] |> Enum.map(&(&1["action"]))) == ["create_invite", "edit_collaborator"]
+      assert (json_response(second_page, 200)["data"] |> Enum.map(&(&1["action"]))) == ["enable_public_link", "start"]
+    end
+
+    test "sort activities by insertedAt in ascendent order", %{conn: conn, user: user} do
+      project = create_project_for_user(user)
+
+      insert(:activity_log, project: project, action: "create_invite", inserted_at: Ecto.DateTime.cast!("2000-01-01 00:00:00"))
+      insert(:activity_log, project: project, action: "edit_collaborator", inserted_at: Ecto.DateTime.cast!("2000-01-02 00:00:00"))
+      insert(:activity_log, project: project, action: "enable_public_link", inserted_at: Ecto.DateTime.cast!("2000-01-03 00:00:00"))
+      insert(:activity_log, project: project, action: "start", inserted_at: Ecto.DateTime.cast!("2000-01-04 00:00:00"))
+
+      first_page = get conn, project_activities_path(conn, :activities, project.id, page: 1, limit: 2, sort_by: "insertedAt", sort_asc: true)
+      second_page = get conn, project_activities_path(conn, :activities, project.id, page: 2, limit: 2, sort: "insertedAt", sort_asc: true)
+
+      assert (json_response(first_page, 200)["data"] |> Enum.map(&(&1["action"]))) == ["create_invite", "edit_collaborator"]
+      assert (json_response(second_page, 200)["data"] |> Enum.map(&(&1["action"]))) == ["enable_public_link", "start"]
+    end
+
+    test "sort activities by insertedAt in descendent order", %{conn: conn, user: user} do
+      project = create_project_for_user(user)
+
+      insert(:activity_log, project: project, action: "create_invite", inserted_at: Ecto.DateTime.cast!("2000-01-01 00:00:00"))
+      insert(:activity_log, project: project, action: "edit_collaborator", inserted_at: Ecto.DateTime.cast!("2000-01-02 00:00:00"))
+      insert(:activity_log, project: project, action: "enable_public_link", inserted_at: Ecto.DateTime.cast!("2000-01-03 00:00:00"))
+      insert(:activity_log, project: project, action: "start", inserted_at: Ecto.DateTime.cast!("2000-01-04 00:00:00"))
+
+      first_page = get conn, project_activities_path(conn, :activities, project.id, page: 1, limit: 2, sort_by: "insertedAt", sort_asc: false)
+      second_page = get conn, project_activities_path(conn, :activities, project.id, page: 2, limit: 2, sort_by: "insertedAt", sort_asc: false)
+
+      assert (json_response(first_page, 200)["data"] |> Enum.map(&(&1["action"]))) == ["start", "enable_public_link"]
+      assert (json_response(second_page, 200)["data"] |> Enum.map(&(&1["action"]))) == ["edit_collaborator", "create_invite"]
+    end
+
     test "doesn't list activities of other project", %{conn: conn, user: user} do
       project = create_project_for_user(user)
       project2 = create_project_for_user(user)
-      survey = insert(:survey, project: project2)
+      survey = insert(:survey, project: project)
       collaborator_email = "foo@foo.com"
 
-      ActivityLog.create_invite(project, conn, collaborator_email, "editor") |> Repo.insert
-      ActivityLog.enable_public_link(project2, conn, survey, "results") |> Repo.insert
-
-      invite_log = ActivityLog |> where([log], log.action == "create_invite") |> Repo.one
+      %{id: create_invite_id} = insert(:activity_log, project: project, user: user, entity_type: "project", entity_id: project.id, action: "create_invite", inserted_at: Ecto.DateTime.cast!("2000-01-01 00:00:00"), metadata: %{project_name: project.name, collaborator_email: collaborator_email, role: "editor"})
+      insert(:activity_log, project: project2, action: "enable_public_link", inserted_at: Ecto.DateTime.cast!("2000-01-02 00:00:00"), user: user, entity_type: "survey", entity_id: survey.id, metadata: %{survey_name: survey.name, report_type: "survey_results"})
+      create_invite_log = ActivityLog |> Repo.get!(create_invite_id)
 
       conn = get conn, project_activities_path(conn, :activities, project.id)
       assert json_response(conn, 200)["data"] == [
         %{"user_name" => user.name,
           "action" => "create_invite",
           "entity_type" => "project",
-          "id" => invite_log.id,
-          "remote_ip" => "192.168.0.128",
-          "inserted_at" => NaiveDateTime.to_iso8601(invite_log.inserted_at),
+          "id" => create_invite_log.id,
+          "remote_ip" => "192.168.0.1",
+          "inserted_at" => NaiveDateTime.to_iso8601(create_invite_log.inserted_at),
           "metadata" => %{
             "project_name" => project.name,
             "collaborator_email" => collaborator_email,

--- a/test/js/reducers/activities.spec.js
+++ b/test/js/reducers/activities.spec.js
@@ -8,44 +8,32 @@ describe('activities reducer', () => {
   const initialState = reducer(undefined, {})
 
   it('should handle initial state', () => {
-    expect(initialState).toEqual({fetching: false, filter: null, items: null, order: null, sortBy: 'insertedAt', sortAsc: false, page: {index: 0, size: 15}})
+    expect(initialState).toEqual({fetching: false, projectId: null, items: null, order: [], sortBy: 'insertedAt', sortAsc: false, page: {number: 1, size: 15, totalCount: 0}})
   })
 
   it('should start fetching activities', () => {
     const projectId = 100
-    const result = reducer(initialState, actions.startFetchingActivities(projectId))
+    const result = reducer(initialState, actions.startFetchingActivities(projectId, 3))
     expect(result.fetching).toEqual(true)
-    expect(result.filter && result.filter.projectId).toEqual(projectId)
+    expect(result.page.number).toEqual(3)
+    expect(result.projectId).toEqual(projectId)
   })
 
   it('should receive activities', () => {
     const projectId = 100
     const activities = {'1': {'action': 'edit', 'id': 1}}
-    const r1 = reducer(initialState, actions.startFetchingActivities(projectId))
-    const result = reducer(r1, actions.receiveActivities(projectId, activities))
+    const r1 = reducer(initialState, actions.startFetchingActivities(projectId, 1))
+    const result = reducer(r1, actions.receiveActivities(projectId, 1, activities, 20, [1]))
     expect(result.fetching).toEqual(false)
     expect(result.items).toEqual(activities)
-    expect(result.filter && result.filter.projectId).toEqual(projectId)
+    expect(result.page.totalCount).toEqual(20)
     expect(result.order).toEqual([1])
   })
 
-  it('should sort surveys by insertedAt', () => {
-    const projectId = 100
-    const activities = {'1': {'id': 1, 'insertedAt': '2018-03-01T00:00:00'}, '2': {'id': 2, 'insertedAt': '2018-03-02T00:00:00'}}
-    const r1 = reducer(initialState, actions.startFetchingActivities(projectId))
-    const r2 = reducer(r1, actions.receiveActivities(projectId, activities))
-    const r3 = reducer(r2, actions.sortActivitiesBy('insertedAt'))
-    expect(r3.order).toEqual([1, 2])
-    const r4 = reducer(r3, actions.sortActivitiesBy('insertedAt'))
-    expect(r4.order).toEqual([2, 1])
-  })
-
-  it('should go to next and previous page', () => {
-    const r1 = reducer(initialState, actions.nextActivitiesPage())
-    expect(r1.page).toEqual({index: 15, size: 15})
-    const r2 = reducer(r1, actions.nextActivitiesPage())
-    expect(r2.page).toEqual({index: 30, size: 15})
-    const r3 = reducer(r2, actions.previousActivitiesPage())
-    expect(r3.page).toEqual({index: 15, size: 15})
+  it('should update order', () => {
+    const r1 = reducer(initialState, actions.updateOrder(true))
+    expect(r1.sortAsc).toEqual(true)
+    const r2 = reducer(r1, actions.updateOrder(false))
+    expect(r2.sortAsc).toEqual(false)
   })
 })

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -185,4 +185,10 @@ defmodule Ask.Factory do
       expires_at: Timex.now |> Timex.add(Timex.Duration.from_hours(1))
     }
   end
+
+  def activity_log_factory do
+    %Ask.ActivityLog{
+      remote_ip: "192.168.0.1"
+    }
+  end
 end

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -286,16 +286,20 @@ defmodule Ask.ProjectController do
     sort_by = Map.get(params, "sort_by", "")
     sort_asc = Map.get(params, "sort_asc", "")
 
-    activities = conn
+    all_activities_query = conn
     |> load_project(id)
     |> assoc(:activity_logs)
     |> preload(:user)
+
+    all_activities_count = all_activities_query |> Repo.all |> Enum.count
+
+    activities = all_activities_query
     |> conditional_limit(limit)
     |> conditional_page(limit, page)
     |> sort_activities(sort_by, sort_asc)
     |> Repo.all
 
-    render(conn, "activities.json", activities: activities)
+    render(conn, "activities.json", activities: activities, activities_count: all_activities_count)
   end
 
   defp sort_activities(query, sort_by, sort_asc) do

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -289,11 +289,11 @@ defmodule Ask.ProjectController do
     all_activities_query = conn
     |> load_project(id)
     |> assoc(:activity_logs)
-    |> preload(:user)
 
-    all_activities_count = all_activities_query |> Repo.all |> Enum.count
+    all_activities_count = all_activities_query |> select(count("*")) |> Repo.one
 
     activities = all_activities_query
+    |> preload(:user)
     |> conditional_limit(limit)
     |> conditional_page(limit, page)
     |> sort_activities(sort_by, sort_asc)

--- a/web/controllers/project_controller.ex
+++ b/web/controllers/project_controller.ex
@@ -280,13 +280,32 @@ defmodule Ask.ProjectController do
     render(conn, "collaborators.json", collaborators: memberships ++ invites)
   end
 
-  def activities(conn, %{"project_id" => id}) do
+  def activities(conn, %{"project_id" => id} = params) do
+    limit = Map.get(params, "limit", "")
+    page = Map.get(params, "page", "")
+    sort_by = Map.get(params, "sort_by", "")
+    sort_asc = Map.get(params, "sort_asc", "")
+
     activities = conn
     |> load_project(id)
     |> assoc(:activity_logs)
+    |> preload(:user)
+    |> conditional_limit(limit)
+    |> conditional_page(limit, page)
+    |> sort_activities(sort_by, sort_asc)
     |> Repo.all
-    |> Repo.preload(:user)
 
     render(conn, "activities.json", activities: activities)
+  end
+
+  defp sort_activities(query, sort_by, sort_asc) do
+    case {sort_by, sort_asc} do
+      {"insertedAt", "true"} ->
+        query |> order_by([log], asc: log.inserted_at)
+      {"insertedAt", "false"} ->
+        query |> order_by([log], desc: log.inserted_at)
+      _ ->
+        query
+    end
   end
 end

--- a/web/controllers/respondent_controller.ex
+++ b/web/controllers/respondent_controller.ex
@@ -27,30 +27,6 @@ defmodule Ask.RespondentController do
     render(conn, "index.json", respondents: respondents, respondents_count: respondents_count)
   end
 
-  defp conditional_limit query, limit do
-    case limit do
-      "" -> query
-      number -> query |> limit(^number)
-    end
-  end
-
-  defp conditional_page query, limit, page do
-    limit_number = case limit do
-      "" -> 10
-      _ ->
-        {limit_value, _} = Integer.parse(limit)
-        limit_value
-    end
-
-    case page do
-      "" -> query
-      _ ->
-        {page_number, _} = Integer.parse(page)
-        offset = limit_number * (page_number - 1)
-        query |> offset(^offset)
-    end
-  end
-
   defp sort_respondents(query, sort_by, sort_asc) do
     case {sort_by, sort_asc} do
       {"phoneNumber", "true"} ->

--- a/web/helpers/pagination_helper.ex
+++ b/web/helpers/pagination_helper.ex
@@ -1,0 +1,27 @@
+defmodule Pagination.Helper do
+  import Ecto.Query
+
+  def conditional_limit(query, limit) do
+    case limit do
+      "" -> query
+      number -> query |> limit(^number)
+    end
+  end
+
+  def conditional_page(query, limit, page) do
+    limit_number = case limit do
+      "" -> 10
+      _ ->
+        {limit_value, _} = Integer.parse(limit)
+        limit_value
+    end
+
+    case page do
+      "" -> query
+      _ ->
+        {page_number, _} = Integer.parse(page)
+        offset = limit_number * (page_number - 1)
+        query |> offset(^offset)
+    end
+  end
+end

--- a/web/static/js/actions/activities.js
+++ b/web/static/js/actions/activities.js
@@ -1,41 +1,44 @@
 // @flow
 import * as api from '../api'
 
-export const RECEIVE = 'ACTIVITIES_RECEIVE'
-export const FETCH = 'ACTIVITIES_FETCH'
-export const NEXT_PAGE = 'ACTIVITIES_NEXT_PAGE'
-export const PREVIOUS_PAGE = 'ACTIVITIES_PREVIOUS_PAGE'
-export const SORT = 'ACTIVITIES_SORT'
+export const RECEIVE_ACTIVITIES = 'ACTIVITIES_RECEIVE'
+export const FETCH_ACTIVITIES = 'ACTIVITIES_FETCH'
+export const UPDATE_ACTIVITIES_ORDER = 'ACTIVITIES_UPDATE_ORDER'
 
-export const fetchActivities = (projectId: number) => (dispatch: Function) => {
-  dispatch(startFetchingActivities(projectId))
-  api.fetchActivities(projectId)
+export const fetchActivities = (projectId: number, page: number) => (dispatch: Function, getState: Function) => {
+  const state = getState().activities
+  dispatch(startFetchingActivities(projectId, page))
+  api.fetchActivities(projectId, state.page.size, page, state.sortBy, state.sortAsc)
     .then(response => {
-      dispatch(receiveActivities(projectId, response.entities.activities))
+      dispatch(receiveActivities(projectId, page, response.entities.activities || {}, response.activitiesCount, response.result))
     })
 }
 
-export const startFetchingActivities = (projectId: number) => ({
-  type: FETCH,
-  projectId
-})
-
-export const receiveActivities = (projectId: number, items: IndexedList<any>): ReceiveFilteredItemsAction => ({
-  type: RECEIVE,
+export const startFetchingActivities = (projectId: number, page: number) => ({
+  type: FETCH_ACTIVITIES,
   projectId,
-  items
+  page
 })
 
-export const nextActivitiesPage = () => ({
-  type: NEXT_PAGE
+export const receiveActivities = (projectId: number, page: number, activities: IndexedList<any>, activitiesCount: number, order: Array<number>) => ({
+  type: RECEIVE_ACTIVITIES,
+  projectId,
+  page,
+  activities,
+  activitiesCount,
+  order
 })
 
-export const previousActivitiesPage = () => ({
-  type: PREVIOUS_PAGE
-})
+export const sortActivities = (projectId: number) => (dispatch: Function, getState: Function) => {
+  const state = getState().activities
+  const sortAsc = !state.sortAsc
+  api.fetchActivities(projectId, state.page.size, 1, state.sortBy, sortAsc)
+    .then(response => dispatch(receiveActivities(projectId, 1, response.entities.activities || {}, response.activitiesCount, response.result)))
+  dispatch(updateOrder(sortAsc))
+}
 
-export const sortActivitiesBy = (property: string) => ({
-  type: SORT,
-  property
+export const updateOrder = (sortAsc: boolean) => ({
+  type: UPDATE_ACTIVITIES_ORDER,
+  sortAsc
 })
 

--- a/web/static/js/api.js
+++ b/web/static/js/api.js
@@ -77,6 +77,14 @@ const respondentsCallback = (json, schema) => {
   }
 }
 
+const activitiesCallback = (json, schema) => {
+  return () => {
+    let normalized = normalize(camelizeKeys(json.data.activities), schema)
+    normalized.activitiesCount = parseInt(json.meta.count)
+    return normalized
+  }
+}
+
 const handleResponse = (response, callback) => {
   if (response.ok) {
     return callback()
@@ -316,8 +324,8 @@ export const updateCollaboratorLevel = (projectId, collaboratorEmail, newLevel) 
   return apiPutJSON(`projects/${projectId}/memberships/update`, {}, { email: collaboratorEmail, level: newLevel })
 }
 
-export const fetchActivities = (projectId) => {
-  return apiFetchJSON(`projects/${projectId}/activities`, arrayOf(activitySchema))
+export const fetchActivities = (projectId, limit, page, sortBy, sortAsc) => {
+  return apiFetchJSONWithCallback(`projects/${projectId}/activities?limit=${limit}&page=${page}&sort_by=${sortBy}&sort_asc=${sortAsc}`, arrayOf(activitySchema), {}, activitiesCallback)
 }
 
 export const fetchSettings = () => {

--- a/web/static/js/components/activity/ActivityIndex.jsx
+++ b/web/static/js/components/activity/ActivityIndex.jsx
@@ -9,24 +9,29 @@ import { translate } from 'react-i18next'
 
 class ActivityIndex extends Component {
   componentDidMount() {
-    const { projectId } = this.props
+    const { projectId, pageNumber } = this.props
     if (projectId) {
-      this.props.actions.fetchActivities(projectId)
+      this.props.actions.fetchActivities(projectId, pageNumber)
     }
   }
 
   nextPage(e) {
     e.preventDefault()
-    this.props.actions.nextActivitiesPage()
+
+    const { projectId, pageNumber } = this.props
+    this.props.actions.fetchActivities(projectId, pageNumber + 1)
   }
 
   previousPage(e) {
     e.preventDefault()
-    this.props.actions.previousActivitiesPage()
+
+    const { projectId, pageNumber } = this.props
+    this.props.actions.fetchActivities(projectId, pageNumber - 1)
   }
 
-  sortBy(property) {
-    this.props.actions.sortActivitiesBy(property)
+  sort() {
+    const { projectId } = this.props
+    this.props.actions.sortActivities(projectId)
   }
 
   formatDate(date) {
@@ -76,7 +81,7 @@ class ActivityIndex extends Component {
           <tr>
             <th>{t('User')}</th>
             <th>{t('Action')}</th>
-            <SortableHeader text={t('Last activity')} property='insertedAt' sortBy={sortBy} sortAsc={sortAsc} onClick={(name) => this.sortBy(name)} />
+            <SortableHeader text={t('Last activity')} property='insertedAt' sortBy={sortBy} sortAsc={sortAsc} onClick={() => this.sort()} />
           </tr>
         </thead>
         <tbody>
@@ -109,6 +114,7 @@ ActivityIndex.propTypes = {
   endIndex: PropTypes.number.isRequired,
   hasPreviousPage: PropTypes.bool.isRequired,
   hasNextPage: PropTypes.bool.isRequired,
+  pageNumber: PropTypes.number.isRequired,
   pageSize: PropTypes.number.isRequired
 }
 
@@ -120,21 +126,19 @@ const mapStateToProps = (state, ownProps) => {
   let activities = orderedItems(state.activities.items, state.activities.order)
   const sortBy = state.activities.sortBy
   const sortAsc = state.activities.sortAsc
-  const totalCount = activities ? activities.length : 0
-  const pageIndex = state.activities.page.index
+  const totalCount = state.activities.page.totalCount
+  const pageNumber = state.activities.page.number
   const pageSize = state.activities.page.size
-  if (activities) {
-    activities = activities.slice(pageIndex, pageIndex + pageSize)
-  }
-  const startIndex = Math.min(totalCount, pageIndex + 1)
-  const endIndex = Math.min(pageIndex + pageSize, totalCount)
-  const hasPreviousPage = startIndex > 1
+  const startIndex = (pageNumber - 1) * pageSize + 1
+  const endIndex = Math.min(startIndex + pageSize - 1, totalCount)
+  const hasPreviousPage = pageNumber > 1
   const hasNextPage = endIndex < totalCount
 
   return {
     projectId: ownProps.params.projectId,
     activities,
     totalCount,
+    pageNumber,
     pageSize,
     startIndex,
     endIndex,

--- a/web/static/js/reducers/activities.js
+++ b/web/static/js/reducers/activities.js
@@ -1,21 +1,69 @@
 import * as actions from '../actions/activities'
-import collectionReducer, { projectFilterProvider } from './collection'
-
-const itemsReducer = (state: IndexedList<Project>, action): IndexedList<Project> => {
-  return state
-}
 
 const initialState = {
   fetching: false,
   items: null,
-  filter: null,
-  order: null,
+  order: [],
+  projectId: null,
   sortBy: 'insertedAt',
   sortAsc: false,
   page: {
-    index: 0,
-    size: 15
+    number: 1,
+    size: 15,
+    totalCount: 0
   }
 }
 
-export default collectionReducer(actions, itemsReducer, projectFilterProvider, initialState)
+export default (state = initialState, action) => {
+  switch (action.type) {
+    case actions.FETCH_ACTIVITIES: return fetchActivities(state, action)
+    case actions.RECEIVE_ACTIVITIES: return receiveActivities(state, action)
+    case actions.UPDATE_ACTIVITIES_ORDER: return updateActivitiesOrder(state, action)
+    default: return state
+  }
+}
+
+const fetchActivities = (state, action) => {
+  const sameProject = state.projectId == action.projectId
+
+  const items = sameProject ? state.items : null
+  return {
+    ...state,
+    items,
+    projectId: action.projectId,
+    fetching: true,
+    page: {
+      ...state.page,
+      number: action.page
+    }
+  }
+}
+
+const receiveActivities = (state, action) => {
+  if (state.projectId != action.projectId || state.page.number != action.page) {
+    return state
+  }
+
+  return {
+    ...state,
+    fetching: false,
+    items: action.activities,
+    order: action.order,
+    page: {
+      ...state.page,
+      number: action.page,
+      totalCount: action.activitiesCount
+    }
+  }
+}
+
+const updateActivitiesOrder = (state, action) => {
+  return {
+    ...state,
+    page: {
+      ...state.page,
+      number: 1
+    },
+    sortAsc: action.sortAsc
+  }
+}

--- a/web/views/project_view.ex
+++ b/web/views/project_view.ex
@@ -38,8 +38,8 @@ defmodule Ask.ProjectView do
     }
   end
 
-  def render("activities.json", %{activities: activities}) do
-    %{data: render_many(activities, Ask.ProjectView, "activity.json", as: :activity)}
+  def render("activities.json", %{activities: activities, activities_count: activities_count}) do
+    %{data: %{activities: render_many(activities, Ask.ProjectView, "activity.json", as: :activity)}, meta: %{count: activities_count}}
   end
 
   def render("activity.json", %{activity: activity}) do

--- a/web/web.ex
+++ b/web/web.ex
@@ -40,6 +40,7 @@ defmodule Ask.Web do
 
       import User.Helper
       import CSV.Helper
+      import Pagination.Helper
     end
   end
 


### PR DESCRIPTION
Closes #1281.

Activities reducer is based on `respondents` reducers. Both share a lot of common code. It would have been preferable abstracting this common behaviour in a `streamReducer` class, analogous to `collectionReducer`, but I didn't make it because of time contraints. It can be added as an enhacement for the next milestone. `streamReducer` is intended to support server side pagination