### PR TITLE
Closes #1413. Some dispositions are not being logged in the interactions file

### DIFF
--- a/lib/ask/runtime/broker.ex
+++ b/lib/ask/runtime/broker.ex
@@ -554,8 +554,8 @@ defmodule Ask.Runtime.Broker do
       |> Flow.resulting_disposition(reply_disposition)
       |> Flow.resulting_disposition("completed")
 
-    # If reply_disposition == "completed", change of disposition has already been logged during Session.sync_step
-    if session && new_disposition != old_disposition && reply_disposition != "completed" do
+    # If new_disposition == reply_disposition, change of disposition has already been logged during Session.sync_step
+    if session && new_disposition != old_disposition && new_disposition != reply_disposition do
       Session.log_disposition_changed(respondent, session.current_mode.channel, mode, old_disposition, new_disposition)
     end
 

--- a/lib/ask/runtime/broker.ex
+++ b/lib/ask/runtime/broker.ex
@@ -114,7 +114,6 @@ defmodule Ask.Runtime.Broker do
           mode -> mode
         end
       Session.delivery_confirm(session, title, session_mode)
-      update_respondent_disposition(session, "contacted")
     end
   end
 
@@ -237,7 +236,7 @@ defmodule Ask.Runtime.Broker do
     respondent = respondent
     |> Respondent.changeset(%{questionnaire_id: questionnaire.id, mode: mode, disposition: "queued"})
     |> Repo.update!
-    |> create_disposition_history(respondent.disposition, primary_mode)
+    |> RespondentDispositionHistory.create(respondent.disposition, primary_mode)
 
     primary_channel = RespondentGroup.primary_channel(group, mode)
     fallback_channel = RespondentGroup.fallback_channel(group, mode)
@@ -336,16 +335,6 @@ defmodule Ask.Runtime.Broker do
   def sync_step_internal(session, reply, session_mode) do
     transaction_result = Repo.transaction(fn ->
       try do
-        session = cond do
-          reply == Flow.Message.no_reply ->
-            # no_reply is produced, for example, from a timeout in Verboice
-            session
-          reply == Flow.Message.answer ->
-            update_respondent_disposition(session, "contacted")
-          true ->
-            update_respondent_disposition(session, "started")
-        end
-
         reply = mask_phone_number(session.respondent, reply)
         handle_session_step(Session.sync_step(session, reply, session_mode))
       rescue
@@ -517,7 +506,7 @@ defmodule Ask.Runtime.Broker do
     respondent
     |> Respondent.changeset(%{state: "failed", session: nil, timeout_at: nil, disposition: Flow.failed_disposition_from(respondent.disposition)})
     |> Repo.update!
-    |> create_disposition_history(old_disposition, mode)
+    |> RespondentDispositionHistory.create(old_disposition, mode)
   end
 
   defp update_respondent(respondent, :stopped, disposition) do
@@ -564,23 +553,8 @@ defmodule Ask.Runtime.Broker do
     respondent
     |> Respondent.changeset(%{state: "completed", disposition: new_disposition, session: nil, completed_at: Timex.now, timeout_at: nil})
     |> Repo.update!
-    |> create_disposition_history(old_disposition, mode)
+    |> RespondentDispositionHistory.create(old_disposition, mode)
     |> update_quota_bucket(old_disposition, respondent.session["count_partial_results"])
-  end
-
-  def update_respondent_disposition(session, disposition) do
-    respondent = session.respondent
-    old_disposition = respondent.disposition
-    if Flow.should_update_disposition(old_disposition, disposition) do
-      respondent = respondent
-      |> Respondent.changeset(%{disposition: disposition})
-      |> Repo.update!
-      |> create_disposition_history(old_disposition, session.current_mode |> SessionMode.mode)
-
-      %{session | respondent: respondent}
-    else
-      session
-    end
   end
 
   defp update_respondent_and_set_disposition(respondent, session, dump, timeout, timeout_at, disposition, state) do
@@ -589,7 +563,7 @@ defmodule Ask.Runtime.Broker do
       respondent
       |> Respondent.changeset(%{disposition: disposition, state: state, session: dump, timeout_at: timeout_at})
       |> Repo.update!
-      |> create_disposition_history(old_disposition, session.current_mode |> SessionMode.mode)
+      |> RespondentDispositionHistory.create(old_disposition, session.current_mode |> SessionMode.mode)
       |> update_quota_bucket(old_disposition, session.count_partial_results)
     else
       update_respondent(respondent, {:ok, session, timeout}, nil)
@@ -600,17 +574,6 @@ defmodule Ask.Runtime.Broker do
     timeout_at = Timex.shift(Timex.now, minutes: timeout)
     (respondent |> Repo.preload(:survey)).survey
     |> Survey.next_available_date_time(timeout_at)
-  end
-
-  defp create_disposition_history(respondent, old_disposition, mode) do
-    if respondent.disposition && respondent.disposition != old_disposition do
-      %RespondentDispositionHistory{
-        respondent: respondent,
-        disposition: respondent.disposition,
-        mode: mode}
-      |> Repo.insert!
-    end
-    respondent
   end
 
   defp update_quota_bucket(respondent, old_disposition, count_partial_results) do

--- a/lib/ask/runtime/broker.ex
+++ b/lib/ask/runtime/broker.ex
@@ -503,8 +503,12 @@ defmodule Ask.Runtime.Broker do
     session = respondent.session |> Session.load
     mode = session.current_mode |> SessionMode.mode
     old_disposition = respondent.disposition
+    new_disposition = Flow.failed_disposition_from(respondent.disposition)
+
+    Session.log_disposition_changed(respondent, session.current_mode.channel, mode, old_disposition, new_disposition)
+
     respondent
-    |> Respondent.changeset(%{state: "failed", session: nil, timeout_at: nil, disposition: Flow.failed_disposition_from(respondent.disposition)})
+    |> Respondent.changeset(%{state: "failed", session: nil, timeout_at: nil, disposition: new_disposition})
     |> Repo.update!
     |> RespondentDispositionHistory.create(old_disposition, mode)
   end

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -196,7 +196,7 @@ defmodule Ask.Runtime.Session do
   end
 
   defp log_disposition_changed(respondent, channel, mode, previous_disposition, new_disposition) do
-    SurveyLogger.log(respondent.survey_id, mode, respondent.id, respondent.hashed_number, channel.id, previous_disposition, "disposition changed", new_disposition)
+    SurveyLogger.log(respondent.survey_id, mode, respondent.id, respondent.hashed_number, channel.id, previous_disposition, "disposition changed", String.capitalize(new_disposition))
   end
 
   defp handle_setup_response(setup_response) do

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -44,6 +44,9 @@ defmodule Ask.Runtime.Session do
         end
         {:end, reply, respondent}
       {:ok, flow, reply} ->
+        if Flow.should_update_disposition(respondent.disposition, reply.disposition) do
+          log_disposition_changed(respondent, channel, flow.mode, respondent.disposition, reply.disposition)
+        end
         log_prompts(reply, channel, flow.mode, respondent)
         respondent = runtime_channel |> Channel.ask(respondent, token, reply)
         {:ok, %{session | flow: flow}, reply, current_timeout(session), respondent}

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -195,7 +195,7 @@ defmodule Ask.Runtime.Session do
     log_response({:reply, response}, channel, mode, respondent, disposition)
   end
 
-  defp log_disposition_changed(respondent, channel, mode, previous_disposition, new_disposition) do
+  def log_disposition_changed(respondent, channel, mode, previous_disposition, new_disposition) do
     SurveyLogger.log(respondent.survey_id, mode, respondent.id, respondent.hashed_number, channel.id, previous_disposition, "disposition changed", String.capitalize(new_disposition))
   end
 

--- a/lib/ask/runtime/session.ex
+++ b/lib/ask/runtime/session.ex
@@ -373,6 +373,7 @@ defmodule Ask.Runtime.Session do
       {:end, _, reply} -> reply
       {:ok, _flow, reply} -> reply
       {:no_retries_left, _flow, reply} -> reply
+      {:stopped, _flow, reply} -> reply
       _ -> %Reply{}
     end
 
@@ -425,8 +426,7 @@ defmodule Ask.Runtime.Session do
     end
   end
 
-  defp handle_step_answer(session, {:stopped, _, reply}, current_mode) do
-    log_response({:reply, "STOP"}, current_mode.channel, session.flow.mode, session.respondent, reply.disposition)
+  defp handle_step_answer(session, {:stopped, _, reply}, _current_mode) do
     {:stopped, reply, session.respondent}
   end
 

--- a/test/lib/runtime/broker_test.exs
+++ b/test/lib/runtime/broker_test.exs
@@ -1765,7 +1765,7 @@ defmodule Ask.BrokerTest do
     assert do_you_smoke.disposition == "queued"
 
     assert disposition_changed_to_contacted.survey_id == survey.id
-    assert disposition_changed_to_contacted.action_data == "contacted"
+    assert disposition_changed_to_contacted.action_data == "Contacted"
     assert disposition_changed_to_contacted.action_type == "disposition changed"
     assert disposition_changed_to_contacted.disposition == "queued"
 
@@ -1775,7 +1775,7 @@ defmodule Ask.BrokerTest do
     assert do_smoke.disposition == "contacted"
 
     assert disposition_changed_to_started.survey_id == survey.id
-    assert disposition_changed_to_started.action_data == "started"
+    assert disposition_changed_to_started.action_data == "Started"
     assert disposition_changed_to_started.action_type == "disposition changed"
     assert disposition_changed_to_started.disposition == "contacted"
 
@@ -1872,7 +1872,7 @@ defmodule Ask.BrokerTest do
     assert answer.disposition == "queued"
 
     assert disposition_changed_to_contacted.survey_id == survey.id
-    assert disposition_changed_to_contacted.action_data == "contacted"
+    assert disposition_changed_to_contacted.action_data == "Contacted"
     assert disposition_changed_to_contacted.action_type == "disposition changed"
     assert disposition_changed_to_contacted.disposition == "queued"
 
@@ -1887,7 +1887,7 @@ defmodule Ask.BrokerTest do
     assert do_smoke.disposition == "contacted"
 
     assert disposition_changed_to_started.survey_id == survey.id
-    assert disposition_changed_to_started.action_data == "started"
+    assert disposition_changed_to_started.action_data == "Started"
     assert disposition_changed_to_started.action_type == "disposition changed"
     assert disposition_changed_to_started.disposition == "contacted"
 
@@ -2065,7 +2065,7 @@ defmodule Ask.BrokerTest do
     assert do_you_smoke.disposition == "queued"
 
     assert disposition_changed_to_contacted.survey_id == survey.id
-    assert disposition_changed_to_contacted.action_data == "contacted"
+    assert disposition_changed_to_contacted.action_data == "Contacted"
     assert disposition_changed_to_contacted.action_type == "disposition changed"
     assert disposition_changed_to_contacted.disposition == "queued"
 
@@ -2075,7 +2075,7 @@ defmodule Ask.BrokerTest do
     assert do_smoke.disposition == "contacted"
 
     assert disposition_changed_to_started.survey_id == survey.id
-    assert disposition_changed_to_started.action_data == "started"
+    assert disposition_changed_to_started.action_data == "Started"
     assert disposition_changed_to_started.action_type == "disposition changed"
     assert disposition_changed_to_started.disposition == "contacted"
 
@@ -2204,7 +2204,7 @@ defmodule Ask.BrokerTest do
     assert do_you_smoke.disposition == "queued"
 
     assert disposition_changed_to_contacted.survey_id == survey.id
-    assert disposition_changed_to_contacted.action_data == "contacted"
+    assert disposition_changed_to_contacted.action_data == "Contacted"
     assert disposition_changed_to_contacted.action_type == "disposition changed"
     assert disposition_changed_to_contacted.disposition == "queued"
 
@@ -2214,7 +2214,7 @@ defmodule Ask.BrokerTest do
     assert do_smoke.disposition == "contacted"
 
     assert disposition_changed_to_started.survey_id == survey.id
-    assert disposition_changed_to_started.action_data == "started"
+    assert disposition_changed_to_started.action_data == "Started"
     assert disposition_changed_to_started.action_type == "disposition changed"
     assert disposition_changed_to_started.disposition == "contacted"
 
@@ -2336,7 +2336,7 @@ defmodule Ask.BrokerTest do
     assert answer.disposition == "queued"
 
     assert disposition_changed_to_contacted.survey_id == survey.id
-    assert disposition_changed_to_contacted.action_data == "contacted"
+    assert disposition_changed_to_contacted.action_data == "Contacted"
     assert disposition_changed_to_contacted.action_type == "disposition changed"
     assert disposition_changed_to_contacted.disposition == "queued"
 
@@ -2351,7 +2351,7 @@ defmodule Ask.BrokerTest do
     assert do_smoke.disposition == "contacted"
 
     assert disposition_changed_to_started.survey_id == survey.id
-    assert disposition_changed_to_started.action_data == "started"
+    assert disposition_changed_to_started.action_data == "Started"
     assert disposition_changed_to_started.action_type == "disposition changed"
     assert disposition_changed_to_started.disposition == "contacted"
 
@@ -2525,7 +2525,7 @@ defmodule Ask.BrokerTest do
     assert do_you_smoke.disposition == "queued"
 
     assert disposition_changed_to_contacted.survey_id == survey.id
-    assert disposition_changed_to_contacted.action_data == "contacted"
+    assert disposition_changed_to_contacted.action_data == "Contacted"
     assert disposition_changed_to_contacted.action_type == "disposition changed"
     assert disposition_changed_to_contacted.disposition == "queued"
 
@@ -2535,7 +2535,7 @@ defmodule Ask.BrokerTest do
     assert foo.disposition == "contacted"
 
     assert disposition_changed_to_started.survey_id == survey.id
-    assert disposition_changed_to_started.action_data == "started"
+    assert disposition_changed_to_started.action_data == "Started"
     assert disposition_changed_to_started.action_type == "disposition changed"
     assert disposition_changed_to_started.disposition == "contacted"
 
@@ -2555,7 +2555,7 @@ defmodule Ask.BrokerTest do
     assert dont_smoke.disposition == "started"
 
     assert disposition_changed_to_rejected.survey_id == survey.id
-    assert disposition_changed_to_rejected.action_data == "rejected"
+    assert disposition_changed_to_rejected.action_data == "Rejected"
     assert disposition_changed_to_rejected.action_type == "disposition changed"
     assert disposition_changed_to_rejected.disposition == "started"
 
@@ -2662,9 +2662,9 @@ defmodule Ask.BrokerTest do
     assert answer.disposition == "queued"
 
     assert disposition_changed_to_contacted.survey_id == survey.id
+    assert disposition_changed_to_contacted.action_data == "Contacted"
     assert disposition_changed_to_contacted.action_type == "disposition changed"
     assert disposition_changed_to_contacted.disposition == "queued"
-    assert disposition_changed_to_contacted.action_data == "contacted"
 
     assert do_you_smoke.survey_id == survey.id
     assert do_you_smoke.action_data == "Do you smoke?"
@@ -2677,7 +2677,7 @@ defmodule Ask.BrokerTest do
     assert foo.disposition == "contacted"
 
     assert disposition_changed_to_started.survey_id == survey.id
-    assert disposition_changed_to_started.action_data == "started"
+    assert disposition_changed_to_started.action_data == "Started"
     assert disposition_changed_to_started.action_type == "disposition changed"
     assert disposition_changed_to_started.disposition == "contacted"
 
@@ -2697,7 +2697,7 @@ defmodule Ask.BrokerTest do
     assert dont_smoke.disposition == "started"
 
     assert disposition_changed_to_rejected.survey_id == survey.id
-    assert disposition_changed_to_rejected.action_data == "rejected"
+    assert disposition_changed_to_rejected.action_data == "Rejected"
     assert disposition_changed_to_rejected.action_type == "disposition changed"
     assert disposition_changed_to_rejected.disposition == "started"
 
@@ -3482,7 +3482,7 @@ defmodule Ask.BrokerTest do
     assert do_you_smoke.disposition == "queued"
 
     assert disposition_changed_to_contacted.survey_id == survey.id
-    assert disposition_changed_to_contacted.action_data == "contacted"
+    assert disposition_changed_to_contacted.action_data == "Contacted"
     assert disposition_changed_to_contacted.action_type == "disposition changed"
     assert disposition_changed_to_contacted.disposition == "queued"
 
@@ -3492,7 +3492,7 @@ defmodule Ask.BrokerTest do
     assert response1.disposition == "contacted"
 
     assert disposition_changed_to_started.survey_id == survey.id
-    assert disposition_changed_to_started.action_data == "started"
+    assert disposition_changed_to_started.action_data == "Started"
     assert disposition_changed_to_started.action_type == "disposition changed"
     assert disposition_changed_to_started.disposition == "contacted"
 

--- a/test/lib/runtime/session_test.exs
+++ b/test/lib/runtime/session_test.exs
@@ -904,7 +904,7 @@ defmodule Ask.SessionTest do
 
       disposition_changed_entry = entries |> Enum.at(response_index + 1)
       assert disposition_changed_entry.action_type == "disposition changed"
-      assert disposition_changed_entry.action_data == "interim partial"
+      assert disposition_changed_entry.action_data == "Interim partial"
       assert disposition_changed_entry.disposition == "started"
 
       prompt_entry = entries |> Enum.at(response_index + 2)
@@ -933,7 +933,7 @@ defmodule Ask.SessionTest do
       third_entry = entries |> Enum.at(2)
       assert third_entry.action_type == "disposition changed"
       assert third_entry.disposition == "queued"
-      assert third_entry.action_data == "contacted"
+      assert third_entry.action_data == "Contacted"
       fourth_entry = entries |> Enum.at(3)
       assert fourth_entry.action_type == "prompt"
       assert fourth_entry.disposition == "contacted"

--- a/test/lib/runtime/verboice_channel_test.exs
+++ b/test/lib/runtime/verboice_channel_test.exs
@@ -244,15 +244,22 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       :ok = logger |> GenServer.stop
 
-      assert [enqueueing, call_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+      assert [enqueueing, call_failed, disposition_changed_to_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
 
       assert enqueueing.survey_id == survey.id
       assert enqueueing.action_data == "Enqueueing call"
       assert enqueueing.action_type == "contact"
+      assert enqueueing.disposition == "queued"
 
       assert call_failed.survey_id == survey.id
       assert call_failed.action_data == "some random reason (42)"
       assert call_failed.action_type == "contact"
+      assert call_failed.disposition == "queued"
+
+      assert disposition_changed_to_failed.survey_id == survey.id
+      assert disposition_changed_to_failed.action_data == "Failed"
+      assert disposition_changed_to_failed.action_type == "disposition changed"
+      assert disposition_changed_to_failed.disposition == "queued"
 
       :ok = broker |> GenServer.stop
     end
@@ -282,15 +289,22 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       :ok = logger |> GenServer.stop
 
-      assert [enqueueing, call_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+      assert [enqueueing, call_failed, disposition_changed_to_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
 
       assert enqueueing.survey_id == survey.id
       assert enqueueing.action_data == "Enqueueing call"
       assert enqueueing.action_type == "contact"
+      assert enqueueing.disposition == "queued"
 
       assert call_failed.survey_id == survey.id
       assert call_failed.action_data == "(42)"
       assert call_failed.action_type == "contact"
+      assert call_failed.disposition == "queued"
+
+      assert disposition_changed_to_failed.survey_id == survey.id
+      assert disposition_changed_to_failed.action_data == "Failed"
+      assert disposition_changed_to_failed.action_type == "disposition changed"
+      assert disposition_changed_to_failed.disposition == "queued"
 
       :ok = broker |> GenServer.stop
     end
@@ -321,15 +335,22 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       :ok = logger |> GenServer.stop
 
-      assert [enqueueing, call_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+      assert [enqueueing, call_failed, disposition_changed_to_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
 
       assert enqueueing.survey_id == survey.id
       assert enqueueing.action_data == "Enqueueing call"
       assert enqueueing.action_type == "contact"
+      assert enqueueing.disposition == "queued"
 
       assert call_failed.survey_id == survey.id
       assert call_failed.action_data == "some random reason"
       assert call_failed.action_type == "contact"
+      assert call_failed.disposition == "queued"
+
+      assert disposition_changed_to_failed.survey_id == survey.id
+      assert disposition_changed_to_failed.action_data == "Failed"
+      assert disposition_changed_to_failed.action_type == "disposition changed"
+      assert disposition_changed_to_failed.disposition == "queued"
 
       :ok = broker |> GenServer.stop
     end
@@ -360,15 +381,22 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       :ok = logger |> GenServer.stop
 
-      assert [enqueueing, call_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+      assert [enqueueing, call_failed, disposition_changed_to_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
 
       assert enqueueing.survey_id == survey.id
       assert enqueueing.action_data == "Enqueueing call"
       assert enqueueing.action_type == "contact"
+      assert enqueueing.disposition == "queued"
 
       assert call_failed.survey_id == survey.id
       assert call_failed.action_data == "failed"
       assert call_failed.action_type == "contact"
+      assert enqueueing.disposition == "queued"
+
+      assert disposition_changed_to_failed.survey_id == survey.id
+      assert disposition_changed_to_failed.action_data == "Failed"
+      assert disposition_changed_to_failed.action_type == "disposition changed"
+      assert disposition_changed_to_failed.disposition == "queued"
 
       :ok = broker |> GenServer.stop
     end
@@ -399,15 +427,22 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       :ok = logger |> GenServer.stop
 
-      assert [enqueueing, call_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+      assert [enqueueing, call_failed, disposition_changed_to_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
 
       assert enqueueing.survey_id == survey.id
       assert enqueueing.action_data == "Enqueueing call"
       assert enqueueing.action_type == "contact"
+      assert enqueueing.disposition == "queued"
 
       assert call_failed.survey_id == survey.id
       assert call_failed.action_data == "no-answer: another reason (foo)"
       assert call_failed.action_type == "contact"
+      assert call_failed.disposition == "queued"
+
+      assert disposition_changed_to_failed.survey_id == survey.id
+      assert disposition_changed_to_failed.action_data == "Failed"
+      assert disposition_changed_to_failed.action_type == "disposition changed"
+      assert disposition_changed_to_failed.disposition == "queued"
 
       :ok = broker |> GenServer.stop
     end
@@ -438,15 +473,22 @@ defmodule Ask.Runtime.VerboiceChannelTest do
 
       :ok = logger |> GenServer.stop
 
-      assert [enqueueing, call_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
+      assert [enqueueing, call_failed, disposition_changed_to_failed] = (respondent |> Repo.preload(:survey_log_entries)).survey_log_entries
 
       assert enqueueing.survey_id == survey.id
       assert enqueueing.action_data == "Enqueueing call"
       assert enqueueing.action_type == "contact"
+      assert enqueueing.disposition == "queued"
 
       assert call_failed.survey_id == survey.id
       assert call_failed.action_data == "busy: yet another reason (bar)"
       assert call_failed.action_type == "contact"
+      assert call_failed.disposition == "queued"
+
+      assert disposition_changed_to_failed.survey_id == survey.id
+      assert disposition_changed_to_failed.action_data == "Failed"
+      assert disposition_changed_to_failed.action_type == "disposition changed"
+      assert disposition_changed_to_failed.disposition == "queued"
 
       :ok = broker |> GenServer.stop
     end

--- a/test/support/dummy_steps.ex
+++ b/test/support/dummy_steps.ex
@@ -495,6 +495,40 @@ defmodule Ask.DummySteps do
         )
       ]
 
+      @flag_step_after_multiple_choice [
+        multiple_choice_step(
+          id: "bbb",
+          title: "Do you exercise?",
+          prompt: prompt(
+            sms: sms_prompt("Do you exercise? Reply 1 for YES, 2 for NO"),
+            ivr: tts_prompt("Do you exercise? Reply 1 for YES, 2 for NO")
+          ),
+          store: "Exercises",
+          choices: [
+            choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["1"])),
+            choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["2"]))
+          ]
+        ),
+        flag_step(
+          id: "aaa",
+          title: "Let there be rock",
+          disposition: "interim partial"
+        ),
+        multiple_choice_step(
+          id: "eee",
+          title: "Is this the last question?",
+          prompt: prompt(
+            sms: sms_prompt("Is this the last question?"),
+            ivr: tts_prompt("Is this the last question?")
+          ),
+          store: "Last",
+          choices: [
+            choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["1"])),
+            choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["2"]))
+          ]
+        )
+      ]
+
       @flag_steps_ineligible_skip_logic [
         multiple_choice_step(
           id: "aaa",

--- a/test/support/dummy_steps.ex
+++ b/test/support/dummy_steps.ex
@@ -529,6 +529,27 @@ defmodule Ask.DummySteps do
         )
       ]
 
+      @completed_flag_step_after_multiple_choice [
+        multiple_choice_step(
+          id: "bbb",
+          title: "Do you exercise?",
+          prompt: prompt(
+            sms: sms_prompt("Do you exercise? Reply 1 for YES, 2 for NO"),
+            ivr: tts_prompt("Do you exercise? Reply 1 for YES, 2 for NO")
+          ),
+          store: "Exercises",
+          choices: [
+            choice(value: "Yes", responses: responses(sms: ["Yes", "Y", "1"], ivr: ["1"])),
+            choice(value: "No", responses: responses(sms: ["No", "N", "2"], ivr: ["2"]))
+          ]
+        ),
+        flag_step(
+          id: "aaa",
+          title: "Let there be rock",
+          disposition: "completed"
+        )
+      ]
+
       @flag_steps_ineligible_skip_logic [
         multiple_choice_step(
           id: "aaa",

--- a/web/models/respondent_disposition_history.ex
+++ b/web/models/respondent_disposition_history.ex
@@ -1,5 +1,6 @@
 defmodule Ask.RespondentDispositionHistory do
   use Ask.Web, :model
+  alias Ask.{RespondentDispositionHistory, Repo}
 
   schema "respondent_disposition_history" do
     field :disposition, :string
@@ -16,5 +17,16 @@ defmodule Ask.RespondentDispositionHistory do
     struct
     |> cast(params, [:disposition, :mode])
     |> validate_required([:disposition])
+  end
+
+  def create(respondent, old_disposition, mode) do
+    if respondent.disposition && respondent.disposition != old_disposition do
+      %RespondentDispositionHistory{
+        respondent: respondent,
+        disposition: respondent.disposition,
+        mode: mode}
+      |> Repo.insert!
+    end
+    respondent
   end
 end

--- a/web/models/survey_log_entry.ex
+++ b/web/models/survey_log_entry.ex
@@ -8,7 +8,7 @@ defmodule Ask.SurveyLogEntry do
     field :respondent_hashed_number, :string
     belongs_to :channel, Ask.Channel
     field :disposition, :string
-    field :action_type, :string # One of "prompt", "contact" or "response"
+    field :action_type, :string # One of "prompt", "contact", "response" or "disposition changed"
     field :action_data, :string
     field :timestamp, Ecto.DateTime
 


### PR DESCRIPTION
Changes of dispositions are logged as SurveyLogEntries s where:

```
s.action_type == "disposition changed"
s.action_data == new_disposition
s.disposition == old_disposition
```

The main challenge of this issue is the fact that logic related with changes of dispositions is handled in the broker, while logic related with survey log entries is managed in the session.
Ideal solution would have involved migrating all the logic related with changes of dispositions to the session. However, that wasn't possible because it would have taken too much time.

The chosen approach was to contemplate each change of disposition individually. Whenever it was possible, the survey log entries were added in the session, though some of them are added in the broker.