### PR TITLE
Fix: simulation ended toast can be displayed multiple times

### DIFF
--- a/web/static/js/components/simulation/QuestionnaireSimulation.jsx
+++ b/web/static/js/components/simulation/QuestionnaireSimulation.jsx
@@ -129,10 +129,10 @@ class QuestionnaireSimulation extends Component<Props, State> {
     if (isSimulationTerminated) {
       switch (simulationStatus) {
         case 'expired':
-          window.Materialize.toast(t(`This simulation is expired. Please refresh to start a new one`))
+          window.Materialize.toast(t('This simulation is expired. Please refresh to start a new one'))
           break
         case 'ended':
-          window.Materialize.toast(t(`This simulation is ended. Please refresh to start a new one`))
+          window.Materialize.toast(t('This simulation is ended. Please refresh to start a new one'))
           break
       }
     }


### PR DESCRIPTION
Mark a simulation has ended when it expired or ended, so we can
never display the expired/ended toast multiple times. This didn't
happen for the SMS and IVR simulators, but the mobileweb one runs in
its own iframe, and can send a message multiple times.

Refactors to only listen to the `message` event for the mobileweb
simulator, and removes the event manually added to `window` when the
component is unmounted, otherwise we'd have a memory leak with
unmounted components continuing to receive the mobileweb simulator
messages, leading to errors in the console, as well as memory that
the Garbage Collector would never reclaim.

closes #1971