### PR TITLE
Left-align for dispositions label and arrows in survey overview

### DIFF
--- a/assets/css/_global.scss
+++ b/assets/css/_global.scss
@@ -1846,3 +1846,12 @@ a.disabled {
     line-height: 2.4rem;
   }
 }
+
+.expand-column {
+  .expand-link-wrapper {
+    display: inline-block;
+    padding-top: 0.4em;
+    margin-right: 1ex;
+    vertical-align: middle;
+  }
+}

--- a/assets/js/components/surveys/SurveyShow.jsx
+++ b/assets/js/components/surveys/SurveyShow.jsx
@@ -527,17 +527,19 @@ class SurveyShow extends Component<any, State> {
     }
     const groupRow = (
       <tr key={group}>
-        <td>{dispositionGroupLabel(group)}</td>
+        <td className="expand-column">
+          <div className="expand-link-wrapper">
+            <a className="link" onClick={(e) => this.expandGroup(group)}>
+              <i className="material-icons grey-text">
+                {this.state[group] ? "expand_less" : "expand_more"}
+              </i>
+            </a>
+          </div>
+          {dispositionGroupLabel(group)}
+        </td>
         {groupStatsbyReference(referenceIds, detailsKeys, colorClasses, details)}
         <td className="right-align">{groupStats.count || defaultZeroValue}</td>
         <td className="right-align">{this.round(groupStats.percent)}%</td>
-        <td className="expand-column">
-          <a className="link" onClick={(e) => this.expandGroup(group)}>
-            <i className="material-icons right grey-text">
-              {this.state[group] ? "expand_less" : "expand_more"}
-            </i>
-          </a>
-        </td>
       </tr>
     )
 
@@ -569,7 +571,6 @@ class SurveyShow extends Component<any, State> {
             {referenceColumns}
             <td className="right-align">{individualStat.count}</td>
             <td className="right-align">{this.round(individualStat.percent)}%</td>
-            <td className="expand-column" />
           </tr>
         )
       })
@@ -587,7 +588,7 @@ class SurveyShow extends Component<any, State> {
     return (
       <div className="card overflow">
         <div className="card-table-title">
-          <div>{t("Dispositions")}</div>
+          <div className="left-align">{t("Dispositions")}</div>
           <div className="disposition-flow-chart-link">
             <a
               href="https://github.com/instedd/surveda/wiki/Disposition-flow-chart"


### PR DESCRIPTION
This patch adjusts the alignment of arrows and the dispositions label from #1266.

However I couldn't find the time element to align, I think perhaps it was removed since the issue was posted in 2018.

Here's how the overview table looks with this patch:

![dispositions](https://user-images.githubusercontent.com/124930260/232904958-0b87ee21-4e02-44b7-b9aa-b00b606551c1.png)
