### PR TITLE
Fix: CSV generation feedback for all files

### DIFF
--- a/assets/js/actions/survey.js
+++ b/assets/js/actions/survey.js
@@ -479,7 +479,7 @@ export const fetchRespondentsFilesStatus = (projectId: number, surveyId: number,
 export const generateResultsFile =
   (projectId: number, surveyId: number, filter?: string) => (dispatch: Function) => {
     api.generateResults(projectId, surveyId, filter).then((response) => {
-      return dispatch(generatingFile("respondent-results"))
+      return dispatch(generatingFile(filter ? "respondents_filtered" : "respondents_results"))
     })
   }
 
@@ -500,7 +500,7 @@ export const generateInteractionsFile =
 export const generateDispositionHistoryFile =
   (projectId: number, surveyId: number) => (dispatch: Function) => {
     api.generateDispositionHistory(projectId, surveyId).then((response) => {
-      return dispatch(generatingFile("disposition-history"))
+      return dispatch(generatingFile("disposition_history"))
     })
   }
 


### PR DESCRIPTION
Results and disposition history had inconsistent identifiers between the UI and backend, so the "Generating..." feedback was not being shown.

This commit fixes that, even for filtered results.

The bug was introduced during #2350, and now we finally fix #2385 in full.

[csv-generation-feedback.webm](https://github.com/user-attachments/assets/47585163-f19b-4df6-a38b-7d47be364b0a)