### PR TITLE
Fix: dispositions table's last column color

### DIFF
--- a/assets/css/_card-table.scss
+++ b/assets/css/_card-table.scss
@@ -39,8 +39,8 @@
             }
           }
           &:first-child,
-          &:nth-last-child(2),
-          &:nth-last-child(3) {
+          &:nth-last-child(1),
+          &:nth-last-child(2) {
             @extend .grey-text;
           }
         }


### PR DESCRIPTION
When we moved the expand arrows to the left back in c4d662805bb9656420bf3af9b32a81a432f03cc4 we broke the CSS rules for coloring the table, making the last disposition's column be grey instead of its color, and leaving the percent column in black.

See #1266